### PR TITLE
Fix Qdrant URL in VectorStore

### DIFF
--- a/RagWebScraper/Services/VectorStoreService.cs
+++ b/RagWebScraper/Services/VectorStoreService.cs
@@ -29,7 +29,8 @@ namespace RagWebScraper.Services
             };
 
             var response = await _httpClient.PutAsJsonAsync(
-                $"http://localhost:6333/collections/rag/points", payload);
+                $"{_qdrantBaseUrl}/collections/{_collectionName}/points",
+                payload);
 
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
## Summary
- fix vector upsert to use `_qdrantBaseUrl` and `_collectionName`

## Testing
- `dotnet build RagWebScraper.sln`

------
https://chatgpt.com/codex/tasks/task_e_6846f2240624832cba48dc00364c5581