### PR TITLE
Move PageAnalyzerService to dedicated service

### DIFF
--- a/RagWebScraper/Controllers/RAGAnalyzerController.cs
+++ b/RagWebScraper/Controllers/RAGAnalyzerController.cs
@@ -1,47 +1,7 @@
-﻿// Interface segregation and single responsibility principle applied
 using Microsoft.AspNetCore.Mvc;
 using RagWebScraper.Models;
 using RagWebScraper.Services;
 
-public interface IPageAnalyzerService
-{
-    Task<AnalysisResult> AnalyzePageAsync(string url, List<string> keywords);
-}
-
-// Service implementation for page analysis
-public class PageAnalyzerService : IPageAnalyzerService
-{
-    private readonly IWebScraperService _scraper;
-    private readonly ISentimentAnalyzer _sentiment;
-    private readonly IKeywordExtractor _keywords;
-    private readonly IKeywordContextSentimentService _keywordContextSentimentService;
-
-    public PageAnalyzerService(
-        IWebScraperService scraper,
-        ISentimentAnalyzer sentiment,
-        IKeywordExtractor keywords,
-        IKeywordContextSentimentService keywordContextSentimentService)
-    {
-        _scraper = scraper;
-        _sentiment = sentiment;
-        _keywords = keywords;
-        _keywordContextSentimentService = keywordContextSentimentService;
-    }
-
-    public async Task<AnalysisResult> AnalyzePageAsync(string url, List<string> keywords)
-    {
-        var text = await _scraper.ScrapeTextAsync(url);
-        if (string.IsNullOrWhiteSpace(text)) return null;
-
-        return new AnalysisResult(Enumerable.Empty<LinkedPassage>())
-        {
-            Url = url,
-            PageSentimentScore = _sentiment.AnalyzeSentiment(text),
-            KeywordFrequencies = _keywords.ExtractKeywords(text, keywords),
-            KeywordSentimentScores = _keywordContextSentimentService.ExtractKeywordSentiments(text, keywords)
-        };
-    }
-}
 
 // Controller using SRP and DIP
 [ApiController]

--- a/RagWebScraper/Services/IPageAnalyzerService.cs
+++ b/RagWebScraper/Services/IPageAnalyzerService.cs
@@ -1,0 +1,8 @@
+namespace RagWebScraper.Services;
+
+using RagWebScraper.Models;
+
+public interface IPageAnalyzerService
+{
+    Task<AnalysisResult?> AnalyzePageAsync(string url, List<string> keywords);
+}

--- a/RagWebScraper/Services/PageAnalyzerService.cs
+++ b/RagWebScraper/Services/PageAnalyzerService.cs
@@ -1,0 +1,38 @@
+namespace RagWebScraper.Services;
+
+using RagWebScraper.Models;
+
+public class PageAnalyzerService : IPageAnalyzerService
+{
+    private readonly IWebScraperService _scraper;
+    private readonly ISentimentAnalyzer _sentiment;
+    private readonly IKeywordExtractor _keywords;
+    private readonly IKeywordContextSentimentService _keywordContextSentimentService;
+
+    public PageAnalyzerService(
+        IWebScraperService scraper,
+        ISentimentAnalyzer sentiment,
+        IKeywordExtractor keywords,
+        IKeywordContextSentimentService keywordContextSentimentService)
+    {
+        _scraper = scraper;
+        _sentiment = sentiment;
+        _keywords = keywords;
+        _keywordContextSentimentService = keywordContextSentimentService;
+    }
+
+    public async Task<AnalysisResult?> AnalyzePageAsync(string url, List<string> keywords)
+    {
+        var text = await _scraper.ScrapeTextAsync(url);
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        return new AnalysisResult(Enumerable.Empty<LinkedPassage>())
+        {
+            Url = url,
+            PageSentimentScore = _sentiment.AnalyzeSentiment(text),
+            KeywordFrequencies = _keywords.ExtractKeywords(text, keywords),
+            KeywordSentimentScores = _keywordContextSentimentService.ExtractKeywordSentiments(text, keywords)
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- extract `PageAnalyzerService` and `IPageAnalyzerService` from `RAGAnalyzerController`
- create new service files under `Services`
- keep controller focused on request handling

## Testing
- `dotnet build RagWebScraper.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847883032b4832c8c630bdcb4261a44