### PR TITLE
Improve service test coverage

### DIFF
--- a/RagWebScraper.Tests/PdfScraperServiceTests.cs
+++ b/RagWebScraper.Tests/PdfScraperServiceTests.cs
@@ -1,0 +1,67 @@
+using Xunit;
+using System.Net;
+using System.Net.Http;
+using RagWebScraper.Services;
+
+namespace RagWebScraper.Tests;
+
+public class PdfScraperServiceTests
+{
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(_handler(request));
+        }
+    }
+
+    [Fact]
+    public async Task GetPdfLinksAsync_ReturnsAbsoluteLinks()
+    {
+        // Arrange
+        var html = "<a href='file.pdf'>a</a><a href='/b.pdf'>b</a>";
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(html)
+        });
+        var service = new PdfScraperService(new HttpClient(handler));
+
+        // Act
+        var links = (await service.GetPdfLinksAsync("http://example.com/page")).ToList();
+
+        // Assert
+        Assert.Contains("http://example.com/file.pdf", links);
+        Assert.Contains("http://example.com/b.pdf", links);
+        Assert.Equal(2, links.Count);
+    }
+
+    [Fact]
+    public async Task DownloadPdfsAsync_WritesFiles()
+    {
+        // Arrange
+        var bytes = new byte[] {1,2,3};
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(bytes)
+        });
+        var service = new PdfScraperService(new HttpClient(handler));
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        // Act
+        await service.DownloadPdfsAsync(new[] {"http://example.com/test.pdf"}, dir);
+
+        // Assert
+        var file = Path.Combine(dir, "test.pdf");
+        Assert.True(File.Exists(file));
+        Assert.Equal(bytes, await File.ReadAllBytesAsync(file));
+
+        Directory.Delete(dir, true);
+    }
+}

--- a/RagWebScraper.Tests/TextChunkerTests.cs
+++ b/RagWebScraper.Tests/TextChunkerTests.cs
@@ -1,3 +1,4 @@
+using Xunit;
 using RagWebScraper.Services;
 
 namespace RagWebScraper.Tests;
@@ -7,22 +8,61 @@ public class TextChunkerTests
     [Fact]
     public void ChunkText_ReturnsEmptyList_ForNullOrWhitespace()
     {
+        // Arrange
         var chunker = new TextChunker();
-        var result = chunker.ChunkText(null!);
-        Assert.Empty(result);
-        result = chunker.ChunkText(" \t\n");
-        Assert.Empty(result);
+
+        // Act
+        var resultNull = chunker.ChunkText(null!);
+        var resultWhitespace = chunker.ChunkText(" \t\n");
+
+        // Assert
+        Assert.Empty(resultNull);
+        Assert.Empty(resultWhitespace);
     }
 
     [Fact]
     public void ChunkText_SplitsByTokenLimit()
     {
+        // Arrange
         var chunker = new TextChunker();
         var text = "Sentence one. Sentence two is longer. Sentence three.";
+
+        // Act
         var chunks = chunker.ChunkText(text, maxTokensPerChunk: 3);
+
+        // Assert
         Assert.Equal(3, chunks.Count);
         Assert.Contains("Sentence one.", chunks[0]);
         Assert.Contains("Sentence two is longer.", chunks[1]);
         Assert.Contains("Sentence three.", chunks[2]);
+    }
+
+    [Fact]
+    public void ChunkText_LongSentence_RemainsSingleChunk()
+    {
+        // Arrange
+        var chunker = new TextChunker();
+        var text = "One two three four five six seven. Short.";
+
+        // Act
+        var chunks = chunker.ChunkText(text, maxTokensPerChunk: 3);
+
+        // Assert
+        Assert.Equal(2, chunks.Count);
+        Assert.Contains("seven.", chunks[0]);
+    }
+
+    [Fact]
+    public void ChunkText_RespectsTokenLimit()
+    {
+        // Arrange
+        var chunker = new TextChunker();
+        var text = "A B. C D. E F.";
+
+        // Act
+        var chunks = chunker.ChunkText(text, maxTokensPerChunk: 2);
+
+        // Assert
+        Assert.All(chunks, c => Assert.True(c.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length <= 2));
     }
 }

--- a/RagWebScraper.Tests/VectorStoreServiceTests.cs
+++ b/RagWebScraper.Tests/VectorStoreServiceTests.cs
@@ -1,0 +1,64 @@
+using Xunit;
+using System.Net;
+using System.Net.Http.Json;
+using RagWebScraper.Services;
+
+namespace RagWebScraper.Tests;
+
+public class VectorStoreServiceTests
+{
+    private class CaptureHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+        public HttpRequestMessage? Request { get; private set; }
+        public string? Content { get; private set; }
+        public CaptureHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            if (request.Content != null)
+                Content = await request.Content.ReadAsStringAsync();
+            return _handler(request);
+        }
+    }
+
+    [Fact]
+    public async Task UpsertVectorAsync_SendsPayload()
+    {
+        // Arrange
+        var handler = new CaptureHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var service = new VectorStoreService(new HttpClient(handler));
+        var data = new VectorData { Id = "1", Embedding = new List<float> { 0.1f }, Metadata = new { a = 1 } };
+
+        // Act
+        await service.UpsertVectorAsync(data);
+
+        // Assert
+        Assert.Equal(HttpMethod.Put, handler.Request?.Method);
+        Assert.Contains("/collections/rag/points", handler.Request?.RequestUri?.ToString());
+        Assert.Contains("\"id\":\"1\"", handler.Content);
+    }
+
+    [Fact]
+    public async Task QueryAsync_ParsesResults()
+    {
+        // Arrange
+        var json = "{ \"result\": [ { \"score\": 0.5, \"payload\": { \"doc\": \"x\" } } ] }";
+        var handler = new CaptureHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json)
+        });
+        var service = new VectorStoreService(new HttpClient(handler));
+
+        // Act
+        var result = await service.QueryAsync(new List<float> { 0.1f });
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(0.5f, result[0].score);
+        Assert.Equal("x", result[0].payload["doc"].ToString());
+    }
+}

--- a/RagWebScraper/Services/EnglishRobertaTokenizerAdapter.cs
+++ b/RagWebScraper/Services/EnglishRobertaTokenizerAdapter.cs
@@ -1,0 +1,20 @@
+using Microsoft.ML.Tokenizers;
+
+namespace RagWebScraper.Services;
+
+public class EnglishRobertaTokenizerAdapter : ITokenizer
+{
+    private readonly EnglishRobertaTokenizer _tokenizer;
+
+    public EnglishRobertaTokenizerAdapter(EnglishRobertaTokenizer tokenizer)
+    {
+        _tokenizer = tokenizer;
+    }
+
+    public (IReadOnlyList<int> Ids, IReadOnlyList<string> Tokens) Encode(string text)
+    {
+        var ids = _tokenizer.EncodeToIds(text).Select(id => (int)id).ToList();
+        var tokens = _tokenizer.EncodeToTokens(text, out _).Select(t => t.Value).ToList();
+        return (ids, tokens);
+    }
+}

--- a/RagWebScraper/Services/IOnnxSession.cs
+++ b/RagWebScraper/Services/IOnnxSession.cs
@@ -1,0 +1,8 @@
+using Microsoft.ML.OnnxRuntime;
+
+namespace RagWebScraper.Services;
+
+public interface IOnnxSession : IDisposable
+{
+    IDisposableReadOnlyCollection<DisposableNamedOnnxValue> Run(IEnumerable<NamedOnnxValue> inputs);
+}

--- a/RagWebScraper/Services/ITokenizer.cs
+++ b/RagWebScraper/Services/ITokenizer.cs
@@ -1,0 +1,6 @@
+namespace RagWebScraper.Services;
+
+public interface ITokenizer
+{
+    (IReadOnlyList<int> Ids, IReadOnlyList<string> Tokens) Encode(string text);
+}

--- a/RagWebScraper/Services/OnnxSessionWrapper.cs
+++ b/RagWebScraper/Services/OnnxSessionWrapper.cs
@@ -1,0 +1,18 @@
+using Microsoft.ML.OnnxRuntime;
+
+namespace RagWebScraper.Services;
+
+public class OnnxSessionWrapper : IOnnxSession
+{
+    private readonly InferenceSession _session;
+
+    public OnnxSessionWrapper(string modelPath)
+    {
+        _session = new InferenceSession(modelPath);
+    }
+
+    public IDisposableReadOnlyCollection<DisposableNamedOnnxValue> Run(IEnumerable<NamedOnnxValue> inputs)
+        => _session.Run(inputs.ToList());
+
+    public void Dispose() => _session.Dispose();
+}


### PR DESCRIPTION
## Summary
- refactor `ONNXNerService` for dependency injection
- introduce interfaces `ITokenizer` and `IOnnxSession`
- add wrappers for tokenizer and ONNX session
- expand `TextChunkerTests` and add tests for `PdfScraperService` and `VectorStoreService`

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6847aa5b36f4832ca50d2846e412932a