### PR TITLE
Show NER labels with XML tags in Knowledge Graph

### DIFF
--- a/RagWebScraper/Models/EntityGraphResult.cs
+++ b/RagWebScraper/Models/EntityGraphResult.cs
@@ -3,4 +3,8 @@ public class EntityGraphResult
 {
     public List<EntityNode> Nodes { get; set; } = new();
     public List<EntityEdge> Edges { get; set; } = new();
+    /// <summary>
+    /// Sentences annotated with XML tags for each token label.
+    /// </summary>
+    public List<string> LabeledSentences { get; set; } = new();
 }

--- a/RagWebScraper/Pages/KnowledgeGraph.razor
+++ b/RagWebScraper/Pages/KnowledgeGraph.razor
@@ -36,6 +36,14 @@
                     }
                 </ul>
 
+                <h5>Tagged Sentences</h5>
+                <ol>
+                    @foreach (var sentence in graph.Result.LabeledSentences)
+                    {
+                        <li><pre class="m-0">@sentence</pre></li>
+                    }
+                </ol>
+
                 <h5>Relationships</h5>
                 <ul>
                     @foreach (var edge in graph.Result.Edges)

--- a/RagWebScraper/Services/KnowledgeGraphService.cs
+++ b/RagWebScraper/Services/KnowledgeGraphService.cs
@@ -5,34 +5,56 @@ public class KnowledgeGraphService : IKnowledgeGraphService
 {
     private readonly IEntityGraphExtractor _graphExtractor;
     private readonly PdfResultStore _resultStore;
+    private readonly INerService _nerService;
 
-    public KnowledgeGraphService(IEntityGraphExtractor graphExtractor, PdfResultStore resultStore)
+    public KnowledgeGraphService(IEntityGraphExtractor graphExtractor, PdfResultStore resultStore, INerService nerService)
     {
         _graphExtractor = graphExtractor;
         _resultStore = resultStore;
+        _nerService = nerService;
     }
 
     public Task<EntityGraphResult> AnalyzeTextAsync(string text)
     {
         var graph = _graphExtractor.Extract(text, sourceId: "manual-input");
+        var labeled = BuildLabeledSentences(text);
 
         return Task.FromResult(new EntityGraphResult
         {
             Nodes = graph.Nodes,
-            Edges = graph.Edges
+            Edges = graph.Edges,
+            LabeledSentences = labeled
         });
     }
+
     public Task<EntityGraphResult> AnalyzePdfAsync(string fileName)
     {
         if (!_resultStore.TryGet(fileName, out var result) || string.IsNullOrWhiteSpace(result.RawText))
             throw new InvalidOperationException($"No processed PDF found for '{fileName}'.");
 
         var graph = _graphExtractor.Extract(result.RawText, fileName);
+        var labeled = BuildLabeledSentences(result.RawText);
 
         return Task.FromResult(new EntityGraphResult
         {
             Nodes = graph.Nodes,
-            Edges = graph.Edges
+            Edges = graph.Edges,
+            LabeledSentences = labeled
         });
+    }
+
+    private List<string> BuildLabeledSentences(string text)
+    {
+        var sentences = SentenceSplitter.Split(text);
+        var labeled = new List<string>(sentences.Count);
+
+        foreach (var sentence in sentences)
+        {
+            var tokens = _nerService.RecognizeTokensWithLabels(sentence);
+            var xml = string.Join(" ", tokens.Select(t => $"<{t.Label}>{t.Token}</{t.Label}>"));
+            labeled.Add(xml);
+        }
+
+        return labeled;
     }
 }


### PR DESCRIPTION
## Summary
- allow `EntityGraphResult` to hold tagged sentences
- generate tagged sentences in `KnowledgeGraphService`
- display token tags on knowledge graph page

## Testing
- `dotnet build RagWebScraper.sln -c Release`
- `dotnet test RagWebScraper.sln`

------
https://chatgpt.com/codex/tasks/task_e_684842604d74832caf57aa91b7e31a57