### PR TITLE
Improve XML tag display

### DIFF
--- a/RagWebScraper/Pages/KnowledgeGraph.razor
+++ b/RagWebScraper/Pages/KnowledgeGraph.razor
@@ -11,6 +11,7 @@
 @using RagWebScraper.Services
 @using RagWebScraper.Shared
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components
 
 <h3 class="mb-3 text-primary">Knowledge Graph from PDFs</h3>
 
@@ -40,7 +41,9 @@
                 <ol>
                     @foreach (var sentence in graph.Result.LabeledSentences)
                     {
-                        <li><pre class="m-0">@sentence</pre></li>
+                        <li>
+                            <pre class="xml-display m-0">@((MarkupString)FormatXml(sentence))</pre>
+                        </li>
                     }
                 </ol>
 
@@ -162,5 +165,14 @@
         AppState.OnChange -= StateHasChanged;
         _pollingTimer?.Stop();
         _pollingTimer?.Dispose();
+    }
+
+    private static string FormatXml(string xml)
+    {
+        var encoded = System.Net.WebUtility.HtmlEncode(xml ?? string.Empty);
+        return System.Text.RegularExpressions.Regex.Replace(
+            encoded,
+            @"&lt;/?[A-Za-z0-9-]+&gt;",
+            m => $"<span class=\"xml-tag\">{m.Value}</span>");
     }
 }

--- a/RagWebScraper/wwwroot/css/app.css
+++ b/RagWebScraper/wwwroot/css/app.css
@@ -56,3 +56,11 @@ h1:focus {
     font-weight: bold;
 }
 
+pre.xml-display {
+    white-space: pre-wrap;
+    font-family: Consolas, "Courier New", monospace;
+}
+pre.xml-display .xml-tag {
+    color: #1b6ec2;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- format XML labels with colored tags for improved readability
- add CSS classes for XML display styling

## Testing
- `dotnet test RagWebScraper.sln --no-build --verbosity normal`
- `dotnet test RagWebScraper.Tests/RagWebScraper.Tests.csproj --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68486f484134832ca7087a28ed9154e6