### PR TITLE
Implement document clustering with TF‑IDF and KMeans

### DIFF
--- a/RagWebScraper.Tests/DocumentClustererTests.cs
+++ b/RagWebScraper.Tests/DocumentClustererTests.cs
@@ -1,0 +1,27 @@
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class DocumentClustererTests
+{
+    [Fact]
+    public async Task ClusterAsync_ReturnsClusterAssignments()
+    {
+        var docs = new[]
+        {
+            new Document(Guid.NewGuid(), "Cats are wonderful pets"),
+            new Document(Guid.NewGuid(), "Dogs are loyal companions"),
+            new Document(Guid.NewGuid(), "I love my cat"),
+            new Document(Guid.NewGuid(), "Walking the dog is fun")
+        };
+
+        IDocumentClusterer clusterer = new TfidfKMeansClusterer();
+        var result = await clusterer.ClusterAsync(docs, numberOfClusters: 2);
+
+        Assert.Equal(docs.Length, result.Count);
+        var unique = new HashSet<int>(result.Values);
+        Assert.Equal(2, unique.Count);
+    }
+}

--- a/RagWebScraper/Models/Document.cs
+++ b/RagWebScraper/Models/Document.cs
@@ -1,0 +1,7 @@
+namespace RagWebScraper.Models
+{
+    /// <summary>
+    /// Represents a source document to cluster.
+    /// </summary>
+    public record Document(Guid Id, string Text);
+}

--- a/RagWebScraper/Services/IDocumentClusterer.cs
+++ b/RagWebScraper/Services/IDocumentClusterer.cs
@@ -1,0 +1,18 @@
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services
+{
+    /// <summary>
+    /// Provides functionality to cluster documents by topic.
+    /// </summary>
+    public interface IDocumentClusterer
+    {
+        /// <summary>
+        /// Clusters the supplied documents into the specified number of groups.
+        /// </summary>
+        /// <param name="documents">Documents to cluster.</param>
+        /// <param name="numberOfClusters">Desired number of clusters.</param>
+        /// <returns>Mapping of document ID to cluster ID.</returns>
+        Task<Dictionary<Guid, int>> ClusterAsync(IEnumerable<Document> documents, int numberOfClusters = 5);
+    }
+}

--- a/RagWebScraper/Services/TfidfKMeansClusterer.cs
+++ b/RagWebScraper/Services/TfidfKMeansClusterer.cs
@@ -1,0 +1,59 @@
+using Microsoft.ML;
+using System.Linq;
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services
+{
+    /// <summary>
+    /// Clusters documents using TF-IDF features with a KMeans algorithm.
+    /// </summary>
+    public class TfidfKMeansClusterer : IDocumentClusterer
+    {
+        private readonly MLContext _mlContext;
+
+        public TfidfKMeansClusterer()
+        {
+            // Use a fixed seed for deterministic clustering in tests
+            _mlContext = new MLContext(seed: 1);
+        }
+
+        public Task<Dictionary<Guid, int>> ClusterAsync(IEnumerable<Document> documents, int numberOfClusters = 5)
+        {
+            if (documents == null)
+                throw new ArgumentNullException(nameof(documents));
+
+            var documentList = documents.ToList();
+            if (documentList.Count == 0)
+                return Task.FromResult(new Dictionary<Guid, int>());
+
+            var data = documentList.Select(d => new DocumentData { Text = d.Text });
+            var dataView = _mlContext.Data.LoadFromEnumerable(data);
+
+            var pipeline = _mlContext.Transforms.Text.FeaturizeText("Features", nameof(Document.Text))
+                .Append(_mlContext.Clustering.Trainers.KMeans(featureColumnName: "Features", numberOfClusters: numberOfClusters));
+
+            var model = pipeline.Fit(dataView);
+            var predictions = model.Transform(dataView);
+
+            var predictedClusters = _mlContext.Data.CreateEnumerable<ClusterPrediction>(predictions, reuseRowObject: false).ToList();
+
+            var result = new Dictionary<Guid, int>(documentList.Count);
+            for (int i = 0; i < documentList.Count; i++)
+            {
+                result[documentList[i].Id] = (int)predictedClusters[i].PredictedLabel;
+            }
+
+            return Task.FromResult(result);
+        }
+
+        private class ClusterPrediction
+        {
+            public uint PredictedLabel { get; set; }
+        }
+
+        private class DocumentData
+        {
+            public string Text { get; set; } = string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Document` model
- define `IDocumentClusterer` interface
- implement `TfidfKMeansClusterer` using ML.NET
- test clustering behaviour with `DocumentClustererTests`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6848c603b69c832c82630b3e0c3efe8f