### PR TITLE
Expose KMeans clustering in UI

### DIFF
--- a/RagWebScraper.Tests/KMeansClusteringPageTests.cs
+++ b/RagWebScraper.Tests/KMeansClusteringPageTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class KMeansClusteringPageTests
+{
+    private class StubClusterer : IDocumentClusterer
+    {
+        public List<Document>? ReceivedDocs { get; private set; }
+        public int ReceivedK { get; private set; }
+        public Dictionary<Guid, int> Result { get; set; } = new();
+
+        public Task<Dictionary<Guid, int>> ClusterAsync(IEnumerable<Document> documents, int numberOfClusters = 5)
+        {
+            ReceivedDocs = documents.ToList();
+            ReceivedK = numberOfClusters;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private static object GetPrivateField(object obj, string name)
+        => obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(obj)!;
+
+    private static void SetPrivateField(object obj, string name, object? value)
+        => obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(obj, value);
+
+    private static Task InvokePrivateMethod(object obj, string name)
+    {
+        var method = obj.GetType().GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (Task)method.Invoke(obj, Array.Empty<object>())!;
+    }
+
+    [Fact]
+    public async Task ClusterDocs_ParsesInputAndCallsClusterer()
+    {
+        var clusterer = new StubClusterer();
+        var page = new RagWebScraper.Pages.KMeansClustering();
+        page.GetType().GetProperty("Clusterer", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(page, clusterer);
+
+        SetPrivateField(page, "documentsInput", "A\nB");
+        SetPrivateField(page, "clusterCount", 2);
+
+        await InvokePrivateMethod(page, "ClusterDocs");
+
+        Assert.Equal(2, clusterer.ReceivedDocs!.Count);
+        Assert.Equal(2, clusterer.ReceivedK);
+        Assert.Same(clusterer.Result, GetPrivateField(page, "clusterResults"));
+    }
+
+    [Fact]
+    public async Task ClusterDocs_NoDocumentsClearsResults()
+    {
+        var clusterer = new StubClusterer { Result = new() { { Guid.NewGuid(), 1 } } };
+        var page = new RagWebScraper.Pages.KMeansClustering();
+        page.GetType().GetProperty("Clusterer", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(page, clusterer);
+
+        SetPrivateField(page, "documentsInput", string.Empty);
+        await InvokePrivateMethod(page, "ClusterDocs");
+
+        Assert.Null(GetPrivateField(page, "clusterResults"));
+    }
+}

--- a/RagWebScraper/Pages/KMeansClustering.razor
+++ b/RagWebScraper/Pages/KMeansClustering.razor
@@ -1,0 +1,67 @@
+@page "/cluster"
+@inject IDocumentClusterer Clusterer
+@using RagWebScraper.Models
+
+<h3 class="mb-3 text-primary">K-Means Document Clustering</h3>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <div class="mb-3">
+            <label class="form-label fw-bold">Enter documents (one per line):</label>
+            <textarea class="form-control" rows="6" @bind="documentsInput"></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label fw-bold">Number of clusters:</label>
+            <InputNumber class="form-control" @bind-Value="clusterCount" Min="2" />
+        </div>
+        <button class="btn btn-primary" @onclick="ClusterDocs">Cluster</button>
+    </div>
+</div>
+
+@if (clusterResults?.Any() == true)
+{
+    <h4 class="text-success">Results</h4>
+    <ClusterChart Results="clusterResults" />
+
+    @foreach (var group in clusterResults.GroupBy(r => r.Value))
+    {
+        <div class="mb-3">
+            <h5>Cluster @group.Key</h5>
+            <ul>
+                @foreach (var doc in group)
+                {
+                    <li>@docTexts[doc.Key]</li>
+                }
+            </ul>
+        </div>
+    }
+}
+
+@code {
+    private string documentsInput = string.Empty;
+    private int clusterCount = 3;
+    private Dictionary<Guid, int>? clusterResults;
+    private readonly Dictionary<Guid, string> docTexts = new();
+
+    private async Task ClusterDocs()
+    {
+        docTexts.Clear();
+        var documents = documentsInput
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(text =>
+            {
+                var id = Guid.NewGuid();
+                docTexts[id] = text;
+                return new Document(id, text);
+            })
+            .ToList();
+
+        if (documents.Count == 0)
+        {
+            clusterResults = null;
+            return;
+        }
+
+        clusterResults = await Clusterer.ClusterAsync(documents, clusterCount);
+    }
+}

--- a/RagWebScraper/Program.cs
+++ b/RagWebScraper/Program.cs
@@ -67,6 +67,7 @@ builder.Services.AddSingleton<IKeywordExtractor, KeywordExtractorService>();
 builder.Services.AddSingleton<IKeywordContextSentimentService, KeywordContextSentimentService>();
 builder.Services.AddSingleton<KeywordSentimentSummaryService>();
 builder.Services.AddSingleton<IPageAnalyzerService, PageAnalyzerService>();
+builder.Services.AddSingleton<IDocumentClusterer, TfidfKMeansClusterer>();
 
 // Scoped / Page-bound
 builder.Services.AddScoped<IAnalysisService, PdfAnalysisService>();

--- a/RagWebScraper/Shared/ClusterChart.razor
+++ b/RagWebScraper/Shared/ClusterChart.razor
@@ -1,0 +1,69 @@
+@using Blazorise.Charts
+
+@if (Results == null || Results.Count == 0)
+{
+    <div class="alert alert-info">No clustering results available.</div>
+}
+else
+{
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-info text-white">Cluster Counts</div>
+        <div class="card-body">
+            <BarChart @ref="clusterChart" TItem="int" Datasets="@(new[] { clusterDataset })" />
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public Dictionary<Guid, int>? Results { get; set; }
+
+    private BarChart<int> clusterChart;
+
+    private BarChartDataset<int> clusterDataset = new()
+    {
+        Label = "Documents",
+        BackgroundColor = "rgba(153, 102, 255, 0.6)",
+        BorderColor = "rgba(153, 102, 255, 1)",
+        BorderWidth = 1
+    };
+
+    private List<string> clusterLabels = new();
+    private bool chartNeedsUpdate;
+
+    protected override void OnParametersSet()
+    {
+        if (clusterDataset.Data != null)
+            clusterDataset.Data.Clear();
+        else
+            clusterDataset.Data = new List<int>();
+
+        clusterLabels.Clear();
+
+        if (Results != null)
+        {
+            var counts = Results.Values
+                .GroupBy(v => v)
+                .OrderBy(g => g.Key)
+                .Select(g => new { ClusterId = g.Key, Count = g.Count() });
+
+            foreach (var item in counts)
+            {
+                clusterLabels.Add($"Cluster {item.ClusterId}");
+                clusterDataset.Data.Add(item.Count);
+            }
+        }
+
+        chartNeedsUpdate = true;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (chartNeedsUpdate && clusterChart != null)
+        {
+            await clusterChart.Clear();
+            await clusterChart.AddLabelsDatasetsAndUpdate(clusterLabels, clusterDataset);
+            chartNeedsUpdate = false;
+        }
+    }
+}

--- a/RagWebScraper/Shared/NavMenu.razor
+++ b/RagWebScraper/Shared/NavMenu.razor
@@ -36,6 +36,11 @@
                         <span class="oi oi-link-45deg" aria-hidden="true"></span> 💫 Cross Links
                     </NavLink>
                 </li>
+                <li class="nav-item">
+                    <NavLink class="nav-link" href="cluster">
+                        <span class="oi oi-graph" aria-hidden="true"></span> 📈 Clustering
+                    </NavLink>
+                </li>
             </ul>
         </div>
     </div>

--- a/RagWebScraper/_Imports.razor
+++ b/RagWebScraper/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using RagWebScraper
 @using RagWebScraper.Shared
+@using RagWebScraper.Services


### PR DESCRIPTION
## Summary
- inject `IDocumentClusterer` service
- add a KMeans clustering page with basic controls
- show cluster counts with a new `ClusterChart` component
- link the page in the navigation menu
- include services namespace in `_Imports`
- add unit tests for KMeans page logic

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6848e44b3b10832c9798a3b632ea49e6