### PR TITLE
Add entity extraction and trend analyzer services

### DIFF
--- a/RagWebScraper.Tests/EntityTrendAnalyzerTests.cs
+++ b/RagWebScraper.Tests/EntityTrendAnalyzerTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class EntityTrendAnalyzerTests
+{
+    [Fact]
+    public void ComputeTrends_GroupsByMonth()
+    {
+        var docs = new[]
+        {
+            new DocumentAnalysisResult(new DateTime(2023,1,1), new []
+            {
+                new Entity("ORG","Microsoft",0,1),
+                new Entity("ORG","OpenAI",2,3)
+            }),
+            new DocumentAnalysisResult(new DateTime(2023,1,5), new []
+            {
+                new Entity("ORG","Microsoft",0,1),
+                new Entity("ORG","Amazon",2,3)
+            }),
+            new DocumentAnalysisResult(new DateTime(2023,2,15), new []
+            {
+                new Entity("ORG","Google",0,1)
+            })
+        };
+
+        ITrendAnalyzer analyzer = new EntityTrendAnalyzer();
+        var trends = analyzer.ComputeTrends(docs, TimeSpan.FromDays(30)).ToList();
+
+        Assert.Equal(4, trends.Count);
+        Assert.Equal(2, trends.Single(t => t.Entity == "Microsoft" && t.Period == "2023-01").Count);
+        Assert.Equal(1, trends.Single(t => t.Entity == "OpenAI" && t.Period == "2023-01").Count);
+        Assert.Equal(1, trends.Single(t => t.Entity == "Amazon" && t.Period == "2023-01").Count);
+        Assert.Equal(1, trends.Single(t => t.Entity == "Google" && t.Period == "2023-02").Count);
+    }
+}

--- a/RagWebScraper.Tests/OnnxEntityExtractorTests.cs
+++ b/RagWebScraper.Tests/OnnxEntityExtractorTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class OnnxEntityExtractorTests
+{
+    private class StubNerService : INerService
+    {
+        public List<NamedEntity> RecognizeEntities(string text) =>
+            new() { new NamedEntity { Text = "Microsoft", Label = "ORG", Start = 0, End = 1 } };
+
+        public List<(string Token, string Label)> RecognizeTokensWithLabels(string sentence) =>
+            new();
+    }
+
+    [Fact]
+    public void ExtractEntities_ReturnsMappedEntities()
+    {
+        IEntityExtractor extractor = new OnnxEntityExtractor(new StubNerService());
+        var result = extractor.ExtractEntities("test").ToList();
+
+        Assert.Single(result);
+        var entity = result[0];
+        Assert.Equal("ORG", entity.EntityType);
+        Assert.Equal("Microsoft", entity.EntityText);
+        Assert.Equal(0, entity.StartIndex);
+        Assert.Equal(1, entity.EndIndex);
+    }
+}

--- a/RagWebScraper/Models/DocumentAnalysisResult.cs
+++ b/RagWebScraper/Models/DocumentAnalysisResult.cs
@@ -1,0 +1,6 @@
+namespace RagWebScraper.Models;
+
+/// <summary>
+/// Represents a document with its analysis date and extracted entities.
+/// </summary>
+public record DocumentAnalysisResult(DateTime Date, IEnumerable<Entity> Entities);

--- a/RagWebScraper/Models/Entity.cs
+++ b/RagWebScraper/Models/Entity.cs
@@ -1,0 +1,6 @@
+namespace RagWebScraper.Models;
+
+/// <summary>
+/// Represents a named entity extracted from text.
+/// </summary>
+public record Entity(string EntityType, string EntityText, int StartIndex, int EndIndex);

--- a/RagWebScraper/Models/EntityTrend.cs
+++ b/RagWebScraper/Models/EntityTrend.cs
@@ -1,0 +1,6 @@
+namespace RagWebScraper.Models;
+
+/// <summary>
+/// Represents the frequency of an entity within a given time period.
+/// </summary>
+public record EntityTrend(string Entity, string Period, int Count);

--- a/RagWebScraper/Services/EntityTrendAnalyzer.cs
+++ b/RagWebScraper/Services/EntityTrendAnalyzer.cs
@@ -1,0 +1,32 @@
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Computes entity frequency trends over time.
+/// </summary>
+public class EntityTrendAnalyzer : ITrendAnalyzer
+{
+    public IEnumerable<EntityTrend> ComputeTrends(IEnumerable<DocumentAnalysisResult> docs, TimeSpan binSize)
+    {
+        var trends = docs
+            .SelectMany(d => d.Entities.Select(e => new { Period = GetPeriod(d.Date, binSize), e.EntityText }))
+            .GroupBy(x => (x.Period, x.EntityText.ToLowerInvariant()))
+            .Select(g => new EntityTrend(g.First().EntityText, g.Key.Period, g.Count()))
+            .OrderBy(t => t.Period)
+            .ThenBy(t => t.Entity);
+
+        return trends;
+    }
+
+    private static string GetPeriod(DateTime date, TimeSpan binSize)
+    {
+        if (binSize.TotalDays >= 90)
+        {
+            int quarter = (date.Month - 1) / 3 + 1;
+            return $"{date.Year}-Q{quarter}";
+        }
+
+        return date.ToString("yyyy-MM");
+    }
+}

--- a/RagWebScraper/Services/IEntityExtractor.cs
+++ b/RagWebScraper/Services/IEntityExtractor.cs
@@ -1,0 +1,11 @@
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Extracts named entities from raw text.
+/// </summary>
+public interface IEntityExtractor
+{
+    IEnumerable<Entity> ExtractEntities(string text);
+}

--- a/RagWebScraper/Services/ITrendAnalyzer.cs
+++ b/RagWebScraper/Services/ITrendAnalyzer.cs
@@ -1,0 +1,11 @@
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Analyzes entity trends over time.
+/// </summary>
+public interface ITrendAnalyzer
+{
+    IEnumerable<EntityTrend> ComputeTrends(IEnumerable<DocumentAnalysisResult> docs, TimeSpan binSize);
+}

--- a/RagWebScraper/Services/OnnxEntityExtractor.cs
+++ b/RagWebScraper/Services/OnnxEntityExtractor.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Entity extractor backed by an ONNX NER model.
+/// </summary>
+public class OnnxEntityExtractor : IEntityExtractor
+{
+    private readonly INerService _nerService;
+
+    public OnnxEntityExtractor(string modelPath, string vocabPath, string mergesPath, string dictionaryPath)
+    {
+        _nerService = new ONNXNerService(modelPath, vocabPath, mergesPath, dictionaryPath);
+    }
+
+    public OnnxEntityExtractor(INerService nerService)
+    {
+        _nerService = nerService;
+    }
+
+    public IEnumerable<Entity> ExtractEntities(string text)
+    {
+        var entities = _nerService.RecognizeEntities(text);
+        return entities.Select(e => new Entity(e.Label, e.Text, e.Start, e.End));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IEntityExtractor` and ONNX-based extractor
- implement `ITrendAnalyzer` and entity trend analyzer
- add records for `Entity`, `DocumentAnalysisResult`, and `EntityTrend`
- unit tests for new services

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684996a8dc98832c804fe5480d4ae129