### PR TITLE
Fix async PDF extraction

### DIFF
--- a/RagWebScraper.Tests/KMeansClusteringPageTests.cs
+++ b/RagWebScraper.Tests/KMeansClusteringPageTests.cs
@@ -51,10 +51,10 @@ public class KMeansClusteringPageTests
 
     private class StubTextExtractor : ITextExtractor
     {
-        public string ExtractText(Stream pdfStream)
+        public Task<string> ExtractTextAsync(Stream pdfStream)
         {
             using var reader = new StreamReader(pdfStream, leaveOpen: true);
-            return reader.ReadToEnd();
+            return Task.FromResult(reader.ReadToEnd());
         }
     }
 

--- a/RagWebScraper.Tests/PdfTextExtractorServiceTests.cs
+++ b/RagWebScraper.Tests/PdfTextExtractorServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using RagWebScraper.Services;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace RagWebScraper.Tests;
 
@@ -37,14 +38,14 @@ public class PdfTextExtractorServiceTests
     }
 
     [Fact]
-    public void ExtractText_ReadsFromNonSeekableStream()
+    public async Task ExtractText_ReadsFromNonSeekableStream()
     {
         // Arrange
         var service = new PdfTextExtractorService();
         using var stream = CreateNonSeekablePdfStream();
 
         // Act
-        var text = service.ExtractText(stream);
+        var text = await service.ExtractTextAsync(stream);
 
         // Assert
         Assert.Contains("Hello, world!", text);

--- a/RagWebScraper/Pages/KMeansClustering.razor
+++ b/RagWebScraper/Pages/KMeansClustering.razor
@@ -90,7 +90,7 @@
             string text;
             if (file.Name.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
             {
-                text = TextExtractor.ExtractText(stream);
+                text = await TextExtractor.ExtractTextAsync(stream);
             }
             else
             {

--- a/RagWebScraper/Services/ITextExtractor.cs
+++ b/RagWebScraper/Services/ITextExtractor.cs
@@ -10,5 +10,5 @@ public interface ITextExtractor
     /// </summary>
     /// <param name="pdfStream">The PDF file stream.</param>
     /// <returns>The extracted plain text.</returns>
-    string ExtractText(Stream pdfStream);
+    Task<string> ExtractTextAsync(Stream pdfStream);
 }

--- a/RagWebScraper/Services/PdfProcessingWorker.cs
+++ b/RagWebScraper/Services/PdfProcessingWorker.cs
@@ -34,7 +34,7 @@ public class PdfProcessingWorker : ChannelBackgroundWorker<PdfProcessingRequest>
 
     protected override async Task ProcessRequestAsync(PdfProcessingRequest request, CancellationToken stoppingToken)
     {
-        var text = _extractor.ExtractText(request.FileStream);
+        var text = await _extractor.ExtractTextAsync(request.FileStream);
         var sentences = SentenceSplitter.Split(text);
 
         var sentiment = _sentiment.AnalyzeSentiment(text);

--- a/RagWebScraper/Services/PdfTextExtractorService.cs
+++ b/RagWebScraper/Services/PdfTextExtractorService.cs
@@ -5,13 +5,13 @@ using System.IO;
 using UglyToad.PdfPig;
 public class PdfTextExtractorService : ITextExtractor
 {
-    public string ExtractText(Stream pdfStream)
+    public async Task<string> ExtractTextAsync(Stream pdfStream)
     {
         MemoryStream? buffer = null;
         if (!pdfStream.CanSeek)
         {
             buffer = new MemoryStream();
-            pdfStream.CopyTo(buffer);
+            await pdfStream.CopyToAsync(buffer);
             buffer.Position = 0;
             pdfStream = buffer;
         }


### PR DESCRIPTION
## Summary
- make `ITextExtractor` asynchronous
- handle non-seekable streams using async API
- adjust PDF processing and clustering logic
- update tests for async extractor

## Testing
- `dotnet test RagWebScraper.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6849ff0a48c8832cae250f5cbdb964d3