### PR TITLE
Show combined cross-document links

### DIFF
--- a/RagWebScraper.Tests/CombinedCrossDocLinkServiceTests.cs
+++ b/RagWebScraper.Tests/CombinedCrossDocLinkServiceTests.cs
@@ -1,0 +1,70 @@
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class CombinedCrossDocLinkServiceTests
+{
+    private class StubAnalyzer : IRagAnalyzerService
+    {
+        private readonly RagAnalysisResult _result;
+        public DocumentSet? ReceivedSet { get; private set; }
+        public StubAnalyzer(RagAnalysisResult result)
+        {
+            _result = result;
+        }
+        public Task<RagAnalysisResult> AnalyzeAsync(DocumentSet set)
+        {
+            ReceivedSet = set;
+            return Task.FromResult(_result);
+        }
+    }
+
+    [Fact]
+    public async Task ComputeLinksAsync_ReturnsLinksAcrossAllDocs()
+    {
+        var expectedLinks = new List<LinkedPassage>
+        {
+            new("a","textA","b","textB",0.9f)
+        };
+        var analyzer = new StubAnalyzer(new RagAnalysisResult(expectedLinks, []));
+        var service = new CombinedCrossDocLinkService(analyzer, new TextChunker());
+
+        var urlResults = new List<AnalysisResult>
+        {
+            new([]){ Url = "a" },
+            new([]){ Url = "b" }
+        };
+        typeof(AnalysisResult).GetProperty("RawText")!.SetValue(urlResults[0], "Sentence one.");
+        typeof(AnalysisResult).GetProperty("RawText")!.SetValue(urlResults[1], "Sentence two.");
+        var pdfResults = new List<AnalysisResult>
+        {
+            new([]){ FileName = "c.pdf" }
+        };
+        typeof(AnalysisResult).GetProperty("RawText")!.SetValue(pdfResults[0], "Sentence three.");
+
+        var links = await service.ComputeLinksAsync(urlResults, pdfResults);
+
+        Assert.Equal(expectedLinks, links);
+        Assert.Equal(3, analyzer.ReceivedSet?.Documents.Count);
+    }
+
+    [Fact]
+    public async Task ComputeLinksAsync_ReturnsEmpty_WhenSingleDoc()
+    {
+        var analyzer = new StubAnalyzer(new RagAnalysisResult(new List<LinkedPassage>(), []));
+        var service = new CombinedCrossDocLinkService(analyzer, new TextChunker());
+
+        var urlResults = new List<AnalysisResult>
+        {
+            new([]){ Url = "a" }
+        };
+        typeof(AnalysisResult).GetProperty("RawText")!.SetValue(urlResults[0], "Only one.");
+
+        var links = await service.ComputeLinksAsync(urlResults, new List<AnalysisResult>());
+
+        Assert.Empty(links);
+        Assert.Null(analyzer.ReceivedSet);
+    }
+}

--- a/RagWebScraper/Pages/CrossDocLinksPage.razor
+++ b/RagWebScraper/Pages/CrossDocLinksPage.razor
@@ -1,5 +1,6 @@
 @page "/cross-links"
 @inject AppStateService AppState
+@inject CombinedCrossDocLinkService CombinedLinkService
 @implements IDisposable
 @using RagWebScraper.Models
 @using System.Linq
@@ -9,12 +10,20 @@
 
 <h3 class="mb-3 text-primary">Cross-Document Links</h3>
 
-@if (!AppState.PdfCrossDocLinks.Any() && !AppState.UrlCrossDocLinks.Any())
+@if (!AppState.AllCrossDocLinks.Any() &&
+    !AppState.PdfCrossDocLinks.Any() &&
+    !AppState.UrlCrossDocLinks.Any())
 {
     <p>No cross-document links available. Please analyze some documents first.</p>
 }
 else
 {
+    if (AppState.AllCrossDocLinks.Any())
+    {
+        <h4 class="mt-3">All Documents</h4>
+        <CrossDocLinks Links="AppState.AllCrossDocLinks" />
+    }
+
     if (AppState.UrlCrossDocLinks.Any())
     {
         <h4 class="mt-3">Web Page Links</h4>
@@ -29,9 +38,20 @@ else
 }
 
 @code {
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         AppState.OnChange += StateHasChanged;
+        await GenerateLinksAsync();
+    }
+
+    private async Task GenerateLinksAsync()
+    {
+        var links = await CombinedLinkService.ComputeLinksAsync(
+            AppState.UrlAnalysisResults,
+            AppState.PdfAnalysisResults);
+        AppState.SetAllCrossDocLinks(links);
+
+        StateHasChanged();
     }
 
     public void Dispose()

--- a/RagWebScraper/Pages/RAGAnalyzer.razor
+++ b/RagWebScraper/Pages/RAGAnalyzer.razor
@@ -5,6 +5,7 @@
 @inject AppStateService AppState
 @inject IRagAnalyzerService RagAnalyzer
 @inject TextChunker Chunker
+@inject CombinedCrossDocLinkService CombinedLinkService
 
 @implements IDisposable
 @using RagWebScraper.Models
@@ -118,11 +119,18 @@
         {
             var docs = result.Select(r => new AnalyzedDocument(
                 r.Url,
-                Chunker.ChunkText(r.RawText).Select(t => new DocumentChunk(r.Url, t)).ToList())).ToList();
+                Chunker.ChunkText(r.RawText)
+                    .Select(t => new DocumentChunk(r.Url, t))
+                    .ToList())).ToList();
             var set = new DocumentSet(docs);
             var analysis = await RagAnalyzer.AnalyzeAsync(set);
             AppState.SetUrlCrossDocLinks(analysis.Links.ToList());
         }
+
+        var combined = await CombinedLinkService.ComputeLinksAsync(
+            result,
+            AppState.PdfAnalysisResults);
+        AppState.SetAllCrossDocLinks(combined);
 
         // Generate and store summary
         var summary = await SummaryService.GenerateSummaryAsync(result);

--- a/RagWebScraper/Pages/UploadPdf.razor
+++ b/RagWebScraper/Pages/UploadPdf.razor
@@ -4,6 +4,7 @@
 @inject AppStateService AppState
 @inject IRagAnalyzerService RagAnalyzer
 @inject TextChunker Chunker
+@inject CombinedCrossDocLinkService CombinedLinkService
 @inject KeywordSentimentSummaryService SummaryService
 
 @implements IDisposable
@@ -183,15 +184,23 @@
                         uploadStatus = "All PDF analyses complete.";
                     }
 
+
                     if (results.Count > 1)
                     {
                         var docs = results.Select(r => new AnalyzedDocument(
                             r.FileName,
-                            Chunker.ChunkText(r.RawText).Select(t => new DocumentChunk(r.FileName, t)).ToList())).ToList();
+                            Chunker.ChunkText(r.RawText)
+                                .Select(t => new DocumentChunk(r.FileName, t))
+                                .ToList())).ToList();
                         var set = new DocumentSet(docs);
                         var analysis = await RagAnalyzer.AnalyzeAsync(set);
                         AppState.SetPdfCrossDocLinks(analysis.Links.ToList());
                     }
+
+                    var combined = await CombinedLinkService.ComputeLinksAsync(
+                        AppState.UrlAnalysisResults,
+                        results);
+                    AppState.SetAllCrossDocLinks(combined);
 
                     _pollingTimer?.Stop();
                     _pollingTimer?.Dispose();

--- a/RagWebScraper/Program.cs
+++ b/RagWebScraper/Program.cs
@@ -75,6 +75,7 @@ builder.Services.AddScoped<IRagAnalyzerService, RagAnalyzerService>();
 builder.Services.AddScoped<IKnowledgeGraphService, KnowledgeGraphService>();
 builder.Services.AddScoped<IEntityGraphExtractor, SpaceEntityGraphExtractor>();
 builder.Services.AddScoped<ICrossDocumentLinker, SemanticCrossLinker>();
+builder.Services.AddScoped<CombinedCrossDocLinkService>();
 
 // ---------------------------------------------
 // HttpClients

--- a/RagWebScraper/Services/CombinedCrossDocLinkService.cs
+++ b/RagWebScraper/Services/CombinedCrossDocLinkService.cs
@@ -1,0 +1,52 @@
+using RagWebScraper.Models;
+using System.Linq;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Generates semantic cross-document links across all analyzed sources.
+/// </summary>
+public class CombinedCrossDocLinkService
+{
+    private readonly IRagAnalyzerService _analyzer;
+    private readonly TextChunker _chunker;
+
+    public CombinedCrossDocLinkService(IRagAnalyzerService analyzer, TextChunker chunker)
+    {
+        _analyzer = analyzer;
+        _chunker = chunker;
+    }
+
+    /// <summary>
+    /// Computes cross-document links across the provided URL and PDF analysis results.
+    /// </summary>
+    /// <param name="urlResults">Analyzed URL results.</param>
+    /// <param name="pdfResults">Analyzed PDF results.</param>
+    public async Task<List<LinkedPassage>> ComputeLinksAsync(IEnumerable<AnalysisResult> urlResults, IEnumerable<AnalysisResult> pdfResults)
+    {
+        var docs = new List<AnalyzedDocument>();
+
+        foreach (var res in urlResults)
+        {
+            var chunks = _chunker.ChunkText(res.RawText)
+                .Select(t => new DocumentChunk(res.Url, t))
+                .ToList();
+            docs.Add(new AnalyzedDocument(res.Url, chunks));
+        }
+
+        foreach (var res in pdfResults)
+        {
+            var chunks = _chunker.ChunkText(res.RawText)
+                .Select(t => new DocumentChunk(res.FileName, t))
+                .ToList();
+            docs.Add(new AnalyzedDocument(res.FileName, chunks));
+        }
+
+        if (docs.Count <= 1)
+            return new List<LinkedPassage>();
+
+        var set = new DocumentSet(docs);
+        var analysis = await _analyzer.AnalyzeAsync(set).ConfigureAwait(false);
+        return analysis.Links.ToList();
+    }
+}

--- a/RagWebScraper/Shared/AppStateService.cs
+++ b/RagWebScraper/Shared/AppStateService.cs
@@ -20,6 +20,7 @@ public class AppStateService
 
     public List<LinkedPassage> PdfCrossDocLinks { get; private set; } = [];
     public List<LinkedPassage> UrlCrossDocLinks { get; private set; } = [];
+    public List<LinkedPassage> AllCrossDocLinks { get; private set; } = [];
 
     public void SetEntityGraphs(IEnumerable<EntityGraph> graphs)
     {
@@ -50,6 +51,12 @@ public class AppStateService
     public void SetUrlCrossDocLinks(List<LinkedPassage> links)
     {
         UrlCrossDocLinks = links;
+        NotifyStateChanged();
+    }
+
+    public void SetAllCrossDocLinks(List<LinkedPassage> links)
+    {
+        AllCrossDocLinks = links;
         NotifyStateChanged();
     }
 


### PR DESCRIPTION
## Summary
- track a combined list of cross-document links in `AppStateService`
- compute links across all analyzed PDFs and URLs with `CombinedCrossDocLinkService`
- recompute combined links when PDFs or URLs are analyzed
- use the new service on the CrossDocLinks page
- test `CombinedCrossDocLinkService` for multiple and single document cases

## Testing
- `dotnet test RagWebScraper.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_684a045c1bec832cb5ed57d1cd27dcf2