### PR TITLE
Graceful handling of empty collections

### DIFF
--- a/RagWebScraper.Tests/CombinedCrossDocLinkServiceTests.cs
+++ b/RagWebScraper.Tests/CombinedCrossDocLinkServiceTests.cs
@@ -67,4 +67,16 @@ public class CombinedCrossDocLinkServiceTests
         Assert.Empty(links);
         Assert.Null(analyzer.ReceivedSet);
     }
+
+    [Fact]
+    public async Task ComputeLinksAsync_ReturnsEmpty_WhenNoDocs()
+    {
+        var analyzer = new StubAnalyzer(new RagAnalysisResult(new List<LinkedPassage>(), []));
+        var service = new CombinedCrossDocLinkService(analyzer, new TextChunker());
+
+        var links = await service.ComputeLinksAsync(new List<AnalysisResult>(), new List<AnalysisResult>());
+
+        Assert.Empty(links);
+        Assert.Null(analyzer.ReceivedSet);
+    }
 }

--- a/RagWebScraper.Tests/EmbeddingServiceTests.cs
+++ b/RagWebScraper.Tests/EmbeddingServiceTests.cs
@@ -1,0 +1,25 @@
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class EmbeddingServiceTests
+{
+    [Fact]
+    public async Task GetEmbeddingsAsync_ReturnsEmpty_ForEmptyInput()
+    {
+        var service = new EmbeddingService("test-key");
+        var result = await service.GetEmbeddingsAsync([]);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetEmbeddingAsync_ReturnsEmpty_ForNullOrWhitespace()
+    {
+        var service = new EmbeddingService("test-key");
+        var resultNull = await service.GetEmbeddingAsync(null!);
+        var resultEmpty = await service.GetEmbeddingAsync(" ");
+        Assert.Empty(resultNull);
+        Assert.Empty(resultEmpty);
+    }
+}

--- a/RagWebScraper.Tests/RagAnalyzerServiceTests.cs
+++ b/RagWebScraper.Tests/RagAnalyzerServiceTests.cs
@@ -1,0 +1,27 @@
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class RagAnalyzerServiceTests
+{
+    private class StubLinker : ICrossDocumentLinker
+    {
+        public Task<IEnumerable<LinkedPassage>> LinkAsync(IEnumerable<DocumentChunk> chunks) => Task.FromResult<IEnumerable<LinkedPassage>>(new List<LinkedPassage>());
+    }
+
+    private class StubExtractor : IEntityGraphExtractor
+    {
+        public EntityGraph Extract(string text, string sourceId) => new EntityGraph(sourceId, [], []);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ReturnsEmpty_ForNoDocuments()
+    {
+        var service = new RagAnalyzerService(new StubLinker(), new StubExtractor());
+        var result = await service.AnalyzeAsync(new DocumentSet([]));
+        Assert.Empty(result.Links);
+        Assert.Empty(result.EntityGraphs);
+    }
+}

--- a/RagWebScraper.Tests/SemanticCrossLinkerTests.cs
+++ b/RagWebScraper.Tests/SemanticCrossLinkerTests.cs
@@ -1,0 +1,30 @@
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class SemanticCrossLinkerTests
+{
+    private class StubEmbedding : IEmbeddingService
+    {
+        public Task<List<float>> GetEmbeddingAsync(string input) => Task.FromResult(new List<float>());
+        public Task<List<float[]>> GetEmbeddingsAsync(IEnumerable<string> inputs) => Task.FromResult(new List<float[]>());
+    }
+
+    [Fact]
+    public async Task LinkAsync_ReturnsEmpty_ForEmptyChunks()
+    {
+        var linker = new SemanticCrossLinker(new StubEmbedding());
+        var result = await linker.LinkAsync([]);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task LinkAsync_ReturnsEmpty_ForSingleChunk()
+    {
+        var linker = new SemanticCrossLinker(new StubEmbedding());
+        var result = await linker.LinkAsync(new[] { new DocumentChunk("a", "text") });
+        Assert.Empty(result);
+    }
+}

--- a/RagWebScraper/Services/CombinedCrossDocLinkService.cs
+++ b/RagWebScraper/Services/CombinedCrossDocLinkService.cs
@@ -26,7 +26,7 @@ public class CombinedCrossDocLinkService
     {
         var docs = new List<AnalyzedDocument>();
 
-        foreach (var res in urlResults)
+        foreach (var res in urlResults ?? Enumerable.Empty<AnalysisResult>())
         {
             var chunks = _chunker.ChunkText(res.RawText)
                 .Select(t => new DocumentChunk(res.Url, t))
@@ -34,7 +34,7 @@ public class CombinedCrossDocLinkService
             docs.Add(new AnalyzedDocument(res.Url, chunks));
         }
 
-        foreach (var res in pdfResults)
+        foreach (var res in pdfResults ?? Enumerable.Empty<AnalysisResult>())
         {
             var chunks = _chunker.ChunkText(res.RawText)
                 .Select(t => new DocumentChunk(res.FileName, t))

--- a/RagWebScraper/Services/EmbeddingService.cs
+++ b/RagWebScraper/Services/EmbeddingService.cs
@@ -14,6 +14,8 @@ namespace RagWebScraper.Services
 
         public async Task<List<float>> GetEmbeddingAsync(string input)
         {
+            if (string.IsNullOrWhiteSpace(input))
+                return new List<float>();
 
             List<float> embeddingsVectors = new List<float>();
             OpenAIEmbeddingCollection? result = await _client.GenerateEmbeddingsAsync([input]);
@@ -36,8 +38,12 @@ namespace RagWebScraper.Services
 
             return embeddingsVectors;
         }
+
         public async Task<List<float[]>> GetEmbeddingsAsync(IEnumerable<string> inputs)
         {
+            if (inputs == null || !inputs.Any())
+                return new List<float[]>();
+
             OpenAIEmbeddingCollection result = await _client.GenerateEmbeddingsAsync(inputs);
             return result.Select(e => e.ToFloats().ToArray()).ToList();
         }

--- a/RagWebScraper/Services/RagAnalyzerService.cs
+++ b/RagWebScraper/Services/RagAnalyzerService.cs
@@ -15,6 +15,9 @@ public sealed class RagAnalyzerService : IRagAnalyzerService
 
     public async Task<RagAnalysisResult> AnalyzeAsync(DocumentSet set)
     {
+        if (set.Documents == null || set.Documents.Count == 0)
+            return new RagAnalysisResult(new List<LinkedPassage>(), new List<EntityGraph>());
+
         var chunks = set.Documents.SelectMany(d => d.Chunks).ToList();
         var links = await _linker.LinkAsync(chunks);
 

--- a/RagWebScraper/Services/SemanticCrossLinker.cs
+++ b/RagWebScraper/Services/SemanticCrossLinker.cs
@@ -14,7 +14,9 @@ namespace RagWebScraper.Services
 
         public async Task<IEnumerable<LinkedPassage>> LinkAsync(IEnumerable<DocumentChunk> chunks)
         {
-            var chunkList = chunks.ToList();
+            var chunkList = chunks?.ToList() ?? new List<DocumentChunk>();
+            if (chunkList.Count < 2)
+                return Enumerable.Empty<LinkedPassage>();
             Console.WriteLine($"[Linker] Chunks to embed: {chunkList.Count}");
 
             var embeddings = await _embedding.GetEmbeddingsAsync(chunkList.Select(c => c.Text)).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add null/empty checks in EmbeddingService, SemanticCrossLinker, RagAnalyzerService and CombinedCrossDocLinkService
- cover empty collection scenarios with new unit tests

## Testing
- `dotnet test RagWebScraper.Tests/RagWebScraper.Tests.csproj -v n`

------
https://chatgpt.com/codex/tasks/task_e_684ac72d1b9c832caab7490f45242ef1