### PR TITLE
Fix KMeans schema mismatch

### DIFF
--- a/RagWebScraper.Tests/DocumentClustererTests.cs
+++ b/RagWebScraper.Tests/DocumentClustererTests.cs
@@ -1,5 +1,6 @@
 using RagWebScraper.Models;
 using RagWebScraper.Services;
+using System.Linq;
 using Xunit;
 
 namespace RagWebScraper.Tests;
@@ -56,6 +57,19 @@ public class DocumentClustererTests
         IDocumentClusterer clusterer = new TfidfKMeansClusterer();
 
         var ex = await Record.ExceptionAsync(() => clusterer.ClusterAsync(docs, 2));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task ClusterAsync_WorksWithLargeVocabulary()
+    {
+        var docs = Enumerable.Range(0, 100)
+            .Select(i => new Document(Guid.NewGuid(), $"word{i} unique{i}")).ToArray();
+
+        IDocumentClusterer clusterer = new TfidfKMeansClusterer();
+
+        var ex = await Record.ExceptionAsync(() => clusterer.ClusterAsync(docs, 5));
 
         Assert.Null(ex);
     }


### PR DESCRIPTION
## Summary
- use hashed word bag features in `TfidfKMeansClusterer`
- add regression test for larger vocabularies

## Testing
- `dotnet test -v:m`

------
https://chatgpt.com/codex/tasks/task_e_684ae6a368c4832c98ed8c34509de089