### PR TITLE
Fix cluster page label lookup

### DIFF
--- a/RagWebScraper.Tests/KMeansClusteringPageTests.cs
+++ b/RagWebScraper.Tests/KMeansClusteringPageTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
 using System.IO;
 using System.Threading.Tasks;
 using RagWebScraper.Models;
@@ -145,5 +146,19 @@ public class KMeansClusteringPageTests
 
         Assert.Null(GetPrivateField(page, "clusterResults"));
         Assert.Equal("too few", GetPrivateField(page, "errorMessage"));
+    }
+
+    [Fact]
+    public void BuildRenderTree_IgnoresMissingLabels()
+    {
+        var page = new RagWebScraper.Pages.KMeansClustering();
+        var results = new Dictionary<Guid, int> { [Guid.NewGuid()] = 0 };
+        SetPrivateField(page, "clusterResults", results);
+        var builder = new RenderTreeBuilder();
+        var method = page.GetType().GetMethod("BuildRenderTree", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var ex = Record.Exception(() => method.Invoke(page, new object[] { builder }));
+
+        Assert.Null(ex);
     }
 }

--- a/RagWebScraper/Pages/KMeansClustering.razor
+++ b/RagWebScraper/Pages/KMeansClustering.razor
@@ -60,7 +60,7 @@
             <ul>
                 @foreach (var doc in group)
                 {
-                    <li>@docLabels[doc.Key]</li>
+                    <li>@(docLabels.TryGetValue(doc.Key, out var label) ? label : doc.Key.ToString())</li>
                 }
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- prevent missing label exceptions in KMeansClustering page
- test that rendering handles missing labels

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684b9fc3e920832c9c917621931d9e6b