### PR TITLE
Add windowed inference for ONNX NER service

### DIFF
--- a/RagWebScraper/Services/IOnnxSession.cs
+++ b/RagWebScraper/Services/IOnnxSession.cs
@@ -12,5 +12,5 @@ public interface IOnnxSession : IDisposable
     /// </summary>
     /// <param name="inputs">Input tensors for the model.</param>
     /// <returns>The model outputs.</returns>
-    IDisposableReadOnlyCollection<DisposableNamedOnnxValue> Run(IEnumerable<NamedOnnxValue> inputs);
+    IDisposableReadOnlyCollection<NamedOnnxValue> Run(IEnumerable<NamedOnnxValue> inputs);
 }

--- a/RagWebScraper/Services/OnnxSessionWrapper.cs
+++ b/RagWebScraper/Services/OnnxSessionWrapper.cs
@@ -11,8 +11,8 @@ public class OnnxSessionWrapper : IOnnxSession
         _session = new InferenceSession(modelPath);
     }
 
-    public IDisposableReadOnlyCollection<DisposableNamedOnnxValue> Run(IEnumerable<NamedOnnxValue> inputs)
-        => _session.Run(inputs.ToList());
+    public IDisposableReadOnlyCollection<NamedOnnxValue> Run(IEnumerable<NamedOnnxValue> inputs)
+        => (IDisposableReadOnlyCollection<NamedOnnxValue>)_session.Run(inputs.ToList());
 
     public void Dispose() => _session.Dispose();
 }


### PR DESCRIPTION
## Summary
- add token window helper and prediction helper in `ONNXNerService`
- run inference over multiple windows for long inputs
- adjust NER session abstraction to return `NamedOnnxValue`
- update unit tests for new behaviour

## Testing
- `dotnet test RagWebScraper.Tests -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684c740a9f80832c8d34be28105cb657