### PR TITLE
Improve PDF processing for large files

### DIFF
--- a/RagWebScraper/Services/PdfProcessingRequest.cs
+++ b/RagWebScraper/Services/PdfProcessingRequest.cs
@@ -1,9 +1,18 @@
 ﻿namespace RagWebScraper.Services
 {
+    /// <summary>
+    /// Represents a queued PDF to process. The file is persisted to a temporary
+    /// path on disk to avoid holding large streams in memory.
+    /// </summary>
     public class PdfProcessingRequest
     {
-        public string FileName { get; init; }
-        public Stream FileStream { get; init; } = default!;
+        /// <summary>Friendly file name originally uploaded.</summary>
+        public string FileName { get; init; } = string.Empty;
+
+        /// <summary>Temporary file path of the uploaded PDF.</summary>
+        public string FilePath { get; init; } = string.Empty;
+
+        /// <summary>List of search keywords for analysis.</summary>
         public List<string> Keywords { get; init; } = new();
     }
 


### PR DESCRIPTION
## Summary
- stream uploaded PDFs to a temp file instead of memory
- queue processing jobs with file paths
- open the temp file in the worker and remove it when done

## Testing
- `dotnet test --no-build` *(fails: OnnxRuntimeException - InvalidProtobuf)*

------
https://chatgpt.com/codex/tasks/task_e_684dc03cdd54832c99c75ef45169f7c7