### PR TITLE
Enable CSV exports with optional display

### DIFF
--- a/RagWebScraper/Pages/CrossDocLinks.razor
+++ b/RagWebScraper/Pages/CrossDocLinks.razor
@@ -1,26 +1,56 @@
 @using RagWebScraper.Models
+@using System.Text
+@inject ICsvExportService CsvExporter
+@inject IJSRuntime JS
+
 @code {
     [Parameter]
     public IEnumerable<LinkedPassage> Links { get; set; } = Enumerable.Empty<LinkedPassage>();
+
+    [Parameter]
+    public bool Display { get; set; } = true;
+
+    [Parameter]
+    public bool AllowDownload { get; set; } = true;
+
+    private async Task DownloadAsync()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for cross links CSV", "cross_links");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "cross_links";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportCrossLinks(Links);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
 }
 
-@if (!Links.Any())
+@if (Display)
 {
-    <p>No cross-document links found.</p>
-}
-else
-{
-    <div class="list-group">
-        @foreach (var link in Links)
+    if (!Links.Any())
+    {
+        <p>No cross-document links found.</p>
+    }
+    else
+    {
+        @if (AllowDownload)
         {
-            <div class="list-group-item">
-                <strong>@link.SourceIdA</strong>: @TextUtils.Truncate(link.TextA, 300)
-                <br />
-                <strong>@link.SourceIdB</strong>: @TextUtils.Truncate(link.TextB, 300)
-                <br />
-                <span class="badge bg-secondary">Similarity: @($"{link.Similarity:P1}")</span>
-            </div>
+            <button class="btn btn-sm btn-secondary mb-2" @onclick="DownloadAsync">
+                <i class="bi bi-download"></i> Download CSV
+            </button>
         }
-    </div>
+        <div class="list-group">
+            @foreach (var link in Links)
+            {
+                <div class="list-group-item">
+                    <strong>@link.SourceIdA</strong>: @TextUtils.Truncate(link.TextA, 300)
+                    <br />
+                    <strong>@link.SourceIdB</strong>: @TextUtils.Truncate(link.TextB, 300)
+                    <br />
+                    <span class="badge bg-secondary">Similarity: @($"{link.Similarity:P1}")</span>
+                </div>
+            }
+        </div>
+    }
 }
 

--- a/RagWebScraper/Pages/RAGAnalyzer.razor
+++ b/RagWebScraper/Pages/RAGAnalyzer.razor
@@ -6,6 +6,9 @@
 @inject IRagAnalyzerService RagAnalyzer
 @inject TextChunker Chunker
 @inject CombinedCrossDocLinkService CombinedLinkService
+@using System.Text
+@inject ICsvExportService CsvExporter
+@inject IJSRuntime JS
 
 @implements IDisposable
 @using RagWebScraper.Models
@@ -35,6 +38,23 @@
 @if (AppState.UrlAnalysisResults != null && AppState.UrlAnalysisResults.Any())
 {
     <h3 class="text-success">Analysis Results</h3>
+    <div class="mb-2">
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="toggleSentiment" @bind="showSentiment" />
+            <label class="form-check-label" for="toggleSentiment">Show Sentiment Chart</label>
+        </div>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="toggleKeyword" @bind="showKeyword" />
+            <label class="form-check-label" for="toggleKeyword">Show Keyword Chart</label>
+        </div>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="toggleLinks" @bind="showLinks" />
+            <label class="form-check-label" for="toggleLinks">Show Cross Links</label>
+        </div>
+        <button class="btn btn-sm btn-secondary ms-3" @onclick="DownloadPageSentimentCsv">Download Sentiment CSV</button>
+        <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadKeywordCsv">Download Keyword CSV</button>
+        <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadLinksCsv">Download Links CSV</button>
+    </div>
     <div class="col-md-6">
         @if (!string.IsNullOrWhiteSpace(AppState.UrlKeywordSummary))
         {
@@ -46,17 +66,17 @@
     </div>
     <div class="row mb-4">
         <div class="col-md-6">
-            <PageSentimentChart Results="AppState.UrlAnalysisResults" />
+            <PageSentimentChart Results="AppState.UrlAnalysisResults" Display="showSentiment" />
         </div>
         <div class="col-md-6">
-            <KeywordSentimentChart Results="AppState.UrlAnalysisResults" />
+            <KeywordSentimentChart Results="AppState.UrlAnalysisResults" Display="showKeyword" />
         </div>
     </div>
 
     @if (AppState.UrlCrossDocLinks?.Any() == true)
     {
         <h3 class="text-primary">Cross-Document Semantic Links</h3>
-        <CrossDocLinks Links="AppState.UrlCrossDocLinks" />
+        <CrossDocLinks Links="AppState.UrlCrossDocLinks" Display="showLinks" />
     }
 
     <Virtualize Items="AppState.UrlAnalysisResults" Context="res">
@@ -88,6 +108,9 @@
 @code {
     private string urlsInput;
     private string searchTerms;
+    private bool showSentiment = true;
+    private bool showKeyword = true;
+    private bool showLinks = true;
 
     private async Task SubmitForAnalysis()
     {
@@ -135,6 +158,39 @@
         // Generate and store summary
         var summary = await SummaryService.GenerateSummaryAsync(result);
         AppState.SetUrlKeywordSummary(summary);
+    }
+
+    private async Task DownloadPageSentimentCsv()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for sentiment CSV", "page_sentiment");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "page_sentiment";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportPageSentiment(AppState.UrlAnalysisResults);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
+
+    private async Task DownloadKeywordCsv()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for keyword sentiment CSV", "keyword_sentiment");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "keyword_sentiment";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportKeywordSentiment(AppState.UrlAnalysisResults);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
+
+    private async Task DownloadLinksCsv()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for cross links CSV", "cross_links");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "cross_links";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportCrossLinks(AppState.UrlCrossDocLinks);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
     }
 
     protected override void OnInitialized()

--- a/RagWebScraper/Pages/UploadPdf.razor
+++ b/RagWebScraper/Pages/UploadPdf.razor
@@ -6,6 +6,9 @@
 @inject TextChunker Chunker
 @inject CombinedCrossDocLinkService CombinedLinkService
 @inject KeywordSentimentSummaryService SummaryService
+@inject ICsvExportService CsvExporter
+@inject IJSRuntime JS
+@using System.Text
 
 @implements IDisposable
 @using System.Timers
@@ -35,11 +38,28 @@
 @if (AppState.PdfAnalysisResults?.Any() == true)
 {
     <h3 class="text-success">PDF Analysis Results</h3>
+    <div class="mb-2">
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="togglePdfSentiment" @bind="showSentiment" />
+            <label class="form-check-label" for="togglePdfSentiment">Show Sentiment Chart</label>
+        </div>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="togglePdfKeyword" @bind="showKeyword" />
+            <label class="form-check-label" for="togglePdfKeyword">Show Keyword Chart</label>
+        </div>
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="checkbox" id="togglePdfLinks" @bind="showLinks" />
+            <label class="form-check-label" for="togglePdfLinks">Show Cross Links</label>
+        </div>
+        <button class="btn btn-sm btn-secondary ms-3" @onclick="DownloadPageSentimentCsv">Download Sentiment CSV</button>
+        <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadKeywordCsv">Download Keyword CSV</button>
+        <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadLinksCsv">Download Links CSV</button>
+    </div>
     <div class="col-md-6">
         @if (AppState.PdfCrossDocLinks?.Any() == true)
         {
             <h3 class="text-primary">Cross-Document Semantic Links</h3>
-            <CrossDocLinks Links="AppState.PdfCrossDocLinks" />
+            <CrossDocLinks Links="AppState.PdfCrossDocLinks" Display="showLinks" />
         }
     </div>
     <div class="col-md-6">
@@ -53,10 +73,10 @@
     </div>
     <div class="row mb-4">
         <div class="col-md-6">
-            <PageSentimentChart Results="AppState.PdfAnalysisResults" />
+            <PageSentimentChart Results="AppState.PdfAnalysisResults" Display="showSentiment" />
         </div>
         <div class="col-md-6">
-            <KeywordSentimentChart Results="AppState.PdfAnalysisResults" />
+            <KeywordSentimentChart Results="AppState.PdfAnalysisResults" Display="showKeyword" />
         </div>
     </div>
 
@@ -104,6 +124,9 @@
 @code {
     private string? uploadStatus;
     private string searchTerms = string.Empty;
+    private bool showSentiment = true;
+    private bool showKeyword = true;
+    private bool showLinks = true;
 
     private Timer? _pollingTimer;
     private List<string> uploadedFileNames = new();
@@ -216,6 +239,39 @@
             uploadStatus = $"Error retrieving results: {ex.Message}";
             await InvokeAsync(StateHasChanged);
         }
+    }
+
+    private async Task DownloadPageSentimentCsv()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for sentiment CSV", "page_sentiment");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "page_sentiment";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportPageSentiment(AppState.PdfAnalysisResults);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
+
+    private async Task DownloadKeywordCsv()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for keyword sentiment CSV", "keyword_sentiment");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "keyword_sentiment";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportKeywordSentiment(AppState.PdfAnalysisResults);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
+
+    private async Task DownloadLinksCsv()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for cross links CSV", "cross_links");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "cross_links";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportCrossLinks(AppState.PdfCrossDocLinks);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
     }
 
     protected override void OnInitialized()

--- a/RagWebScraper/Pages/_Host.cshtml
+++ b/RagWebScraper/Pages/_Host.cshtml
@@ -31,6 +31,8 @@
     <!-- Blazorise charts binding -->
     <script src="_content/Blazorise.Charts/chart.js"></script>
 
+    <script src="download.js"></script>
+
     <!-- Final Blazor runtime -->
     <script src="_framework/blazor.server.js"></script>
 </body>

--- a/RagWebScraper/Program.cs
+++ b/RagWebScraper/Program.cs
@@ -54,6 +54,7 @@ builder.Services.AddSingleton<ITextExtractor, PdfTextExtractorService>();
 builder.Services.AddSingleton<TextChunker>();
 builder.Services.AddSingleton<IEmbeddingService>(new EmbeddingService(openAiKey));
 builder.Services.AddSingleton<IChunkIngestorService, ChunkIngestorService>();
+builder.Services.AddSingleton<ICsvExportService, CsvExportService>();
 builder.Services.AddSingleton<IPdfProcessingQueue, PdfProcessingQueue>();
 builder.Services.AddHostedService<PdfProcessingWorker>();
 builder.Services.AddSingleton<IRagAnalysisQueue, RagAnalysisQueue>();

--- a/RagWebScraper/Services/CsvExportService.cs
+++ b/RagWebScraper/Services/CsvExportService.cs
@@ -1,0 +1,65 @@
+using System.Text;
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Utility service for exporting analysis results to CSV format.
+/// </summary>
+public sealed class CsvExportService : ICsvExportService
+{
+    public byte[] ExportPageSentiment(IEnumerable<AnalysisResult> results)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Source,PageSentimentScore");
+        foreach (var r in results ?? Enumerable.Empty<AnalysisResult>())
+        {
+            var source = string.IsNullOrWhiteSpace(r.Url) ? r.FileName : r.Url;
+            sb.AppendLine($"\"{Escape(source)}\",{r.PageSentimentScore}");
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    public byte[] ExportCrossLinks(IEnumerable<LinkedPassage> links)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("SourceIdA,TextA,SourceIdB,TextB,Similarity");
+        foreach (var l in links ?? Enumerable.Empty<LinkedPassage>())
+        {
+            sb.AppendLine($"\"{Escape(l.SourceIdA)}\",\"{Escape(l.TextA)}\",\"{Escape(l.SourceIdB)}\",\"{Escape(l.TextB)}\",{l.Similarity}");
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    public byte[] ExportKeywordSentiment(IEnumerable<AnalysisResult> results)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Source,Keyword,SentimentScore");
+        foreach (var r in results ?? Enumerable.Empty<AnalysisResult>())
+        {
+            var source = string.IsNullOrWhiteSpace(r.Url) ? r.FileName : r.Url;
+            foreach (var kv in r.KeywordSentimentScores)
+            {
+                sb.AppendLine($"\"{Escape(source)}\",\"{Escape(kv.Key)}\",{kv.Value}");
+            }
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    public byte[] ExportKeywordFrequencies(IEnumerable<AnalysisResult> results)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Source,Keyword,Frequency");
+        foreach (var r in results ?? Enumerable.Empty<AnalysisResult>())
+        {
+            var source = string.IsNullOrWhiteSpace(r.Url) ? r.FileName : r.Url;
+            foreach (var kv in r.KeywordFrequencies)
+            {
+                sb.AppendLine($"\"{Escape(source)}\",\"{Escape(kv.Key)}\",{kv.Value}");
+            }
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    private static string Escape(string input) => input?.Replace("\"", "\"\"") ?? string.Empty;
+}

--- a/RagWebScraper/Services/ICsvExportService.cs
+++ b/RagWebScraper/Services/ICsvExportService.cs
@@ -1,0 +1,11 @@
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+public interface ICsvExportService
+{
+    byte[] ExportPageSentiment(IEnumerable<AnalysisResult> results);
+    byte[] ExportCrossLinks(IEnumerable<LinkedPassage> links);
+    byte[] ExportKeywordSentiment(IEnumerable<AnalysisResult> results);
+    byte[] ExportKeywordFrequencies(IEnumerable<AnalysisResult> results);
+}

--- a/RagWebScraper/Shared/KeywordChart.razor
+++ b/RagWebScraper/Shared/KeywordChart.razor
@@ -1,23 +1,50 @@
 ﻿@using Blazorise.Charts
+@using RagWebScraper.Models
+@using System.Text
+@inject ICsvExportService CsvExporter
+@inject IJSRuntime JS
 
-@if (Frequencies == null || !Frequencies.Any())
+@if (Display)
 {
-    <div class="alert alert-warning">No keywords found.</div>
-}
-else
-{
-    <div class="card shadow-sm mb-4">
-        <div class="card-header bg-success text-white">
-            Keyword Frequencies
+    if (Frequencies == null || !Frequencies.Any())
+    {
+        <div class="alert alert-warning">No keywords found.</div>
+    }
+    else
+    {
+        <div class="card shadow-sm mb-4">
+            <div class="card-header bg-success text-white d-flex justify-content-between">
+                <span>Keyword Frequencies</span>
+                @if (AllowDownload)
+                {
+                    <button class="btn btn-sm btn-light" @onclick="DownloadAsync">
+                        <i class="bi bi-download"></i> CSV
+                    </button>
+                }
+            </div>
+            <div class="card-body">
+                <BarChart @ref="keywordChart" TItem="int" Datasets="@(new[] { keywordData })" />
+            </div>
         </div>
-        <div class="card-body">
-            <BarChart @ref="keywordChart" TItem="int" Datasets="@(new[] { keywordData })" />
-        </div>
-    </div>
+    }
 }
 
 @code {
     [Parameter] public Dictionary<string, int> Frequencies { get; set; }
+    [Parameter] public bool Display { get; set; } = true;
+    [Parameter] public bool AllowDownload { get; set; } = true;
+
+    private async Task DownloadAsync()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for keyword frequency CSV", "keyword_frequencies");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "keyword_frequencies";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportKeywordFrequencies(
+            new[] { new AnalysisResult(Enumerable.Empty<LinkedPassage>()) { KeywordFrequencies = Frequencies ?? new() } });
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
 
     private BarChart<int> keywordChart;
     private BarChartDataset<int> keywordData = new()

--- a/RagWebScraper/Shared/KeywordSentimentChart.razor
+++ b/RagWebScraper/Shared/KeywordSentimentChart.razor
@@ -1,22 +1,49 @@
 ﻿@using RagWebScraper.Models
 @using Blazorise.Charts
+@using System.Text
+@inject ICsvExportService CsvExporter
+@inject IJSRuntime JS
 
-@if (Results == null || !Results.Any())
+@if (Display)
 {
-    <div class="alert alert-info">No keyword sentiment data available.</div>
-}
-else
-{
-    <div class="card shadow-sm mb-4">
-        <div class="card-header bg-success text-white">Keyword-Level Sentiment (Aggregated per Keyword)</div>
-        <div class="card-body">
-            <BarChart @ref="keywordChart" TItem="double" Datasets="@(new[] { keywordDataset })" />
+    if (Results == null || !Results.Any())
+    {
+        <div class="alert alert-info">No keyword sentiment data available.</div>
+    }
+    else
+    {
+        <div class="card shadow-sm mb-4">
+            <div class="card-header bg-success text-white d-flex justify-content-between">
+                <span>Keyword-Level Sentiment (Aggregated per Keyword)</span>
+                @if (AllowDownload)
+                {
+                    <button class="btn btn-sm btn-light" @onclick="DownloadAsync">
+                        <i class="bi bi-download"></i> CSV
+                    </button>
+                }
+            </div>
+            <div class="card-body">
+                <BarChart @ref="keywordChart" TItem="double" Datasets="@(new[] { keywordDataset })" />
+            </div>
         </div>
-    </div>
+    }
 }
 
 @code {
     [Parameter] public List<AnalysisResult> Results { get; set; }
+    [Parameter] public bool Display { get; set; } = true;
+    [Parameter] public bool AllowDownload { get; set; } = true;
+
+    private async Task DownloadAsync()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for keyword sentiment CSV", "keyword_sentiment");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "keyword_sentiment";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportKeywordSentiment(Results);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
 
     private BarChart<double> keywordChart;
     private BarChartDataset<double> keywordDataset = new()

--- a/RagWebScraper/Shared/PageSentimentChart.razor
+++ b/RagWebScraper/Shared/PageSentimentChart.razor
@@ -1,22 +1,49 @@
 ﻿@using RagWebScraper.Models
 @using Blazorise.Charts
+@using System.Text
+@inject ICsvExportService CsvExporter
+@inject IJSRuntime JS
 
-@if (Results == null || !Results.Any())
+@if (Display)
 {
-    <div class="alert alert-info">No page sentiment data available.</div>
-}
-else
-{
-    <div class="card shadow-sm mb-4">
-        <div class="card-header bg-primary text-white">Page-Level Sentiment</div>
-        <div class="card-body">
-            <BarChart @ref="pageChart" TItem="float" Datasets="@(new[] { pageDataset })" />
+    if (Results == null || !Results.Any())
+    {
+        <div class="alert alert-info">No page sentiment data available.</div>
+    }
+    else
+    {
+        <div class="card shadow-sm mb-4">
+            <div class="card-header bg-primary text-white d-flex justify-content-between">
+                <span>Page-Level Sentiment</span>
+                @if (AllowDownload)
+                {
+                    <button class="btn btn-sm btn-light" @onclick="DownloadAsync">
+                        <i class="bi bi-download"></i> CSV
+                    </button>
+                }
+            </div>
+            <div class="card-body">
+                <BarChart @ref="pageChart" TItem="float" Datasets="@(new[] { pageDataset })" />
+            </div>
         </div>
-    </div>
+    }
 }
 
 @code {
     [Parameter] public List<AnalysisResult> Results { get; set; }
+    [Parameter] public bool Display { get; set; } = true;
+    [Parameter] public bool AllowDownload { get; set; } = true;
+
+    private async Task DownloadAsync()
+    {
+        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for sentiment CSV", "page_sentiment");
+        if (string.IsNullOrWhiteSpace(baseName))
+            baseName = "page_sentiment";
+        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
+        var bytes = CsvExporter.ExportPageSentiment(Results);
+        var content = Encoding.UTF8.GetString(bytes);
+        await JS.InvokeVoidAsync("downloadFile", fileName, content);
+    }
 
     private BarChart<float> pageChart;
     private BarChartDataset<float> pageDataset = new()

--- a/RagWebScraper/wwwroot/download.js
+++ b/RagWebScraper/wwwroot/download.js
@@ -1,0 +1,13 @@
+window.downloadFile = (filename, content) => {
+    const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+    if (window.navigator && window.navigator.msSaveBlob) {
+        window.navigator.msSaveBlob(blob, filename);
+    } else {
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    }
+};


### PR DESCRIPTION
## Summary
- add `CsvExportService` for generating CSVs
- register csv export service in DI
- enable download script and add download.js
- allow hiding charts and cross-link components
- add CSV download buttons for analysis results
- allow custom CSV names with timestamp

## Testing
- `dotnet build RagWebScraper.sln -c Release`
- `dotnet test RagWebScraper.sln`


------
https://chatgpt.com/codex/tasks/task_e_684f6e682cbc832c861ebd884df8d780