### PR TITLE
Add CourtListener API JSON services

### DIFF
--- a/RagWebScraper.Tests/CourtListenerServiceTests.cs
+++ b/RagWebScraper.Tests/CourtListenerServiceTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Collections.Generic;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class CourtListenerServiceTests
+{
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) => _handler = handler;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(_handler(request));
+    }
+
+    [Fact]
+    public async Task GetOpinionsAsync_YieldsResultsAcrossPages()
+    {
+        var page1 = new { results = new[]{ new { id = 1, case_name = "a", plain_text = "A" } }, next = "http://host/next" };
+        var page2 = new { results = new[]{ new { id = 2, case_name = "b", plain_text = "B" } }, next = (string?)null };
+
+        var handler = new StubHandler(req =>
+        {
+            var obj = req.RequestUri!.AbsoluteUri.Contains("next") ? page2 : page1;
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(obj) };
+        });
+        var service = new CourtListenerService(new HttpClient(handler));
+
+        var opinions = new List<CourtOpinion>();
+        await foreach (var op in service.GetOpinionsAsync("test"))
+        {
+            opinions.Add(op);
+        }
+
+        Assert.Equal(2, opinions.Count);
+        Assert.Equal(1, opinions[0].Id);
+        Assert.Equal(2, opinions[1].Id);
+    }
+}

--- a/RagWebScraper.Tests/CourtOpinionAnalyzerServiceTests.cs
+++ b/RagWebScraper.Tests/CourtOpinionAnalyzerServiceTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class CourtOpinionAnalyzerServiceTests
+{
+    private class StubSentiment : ISentimentAnalyzer
+    {
+        public float AnalyzeSentiment(string text) => 1.5f;
+    }
+
+    private class StubExtractor : IKeywordExtractor
+    {
+        public Dictionary<string, int> ExtractKeywords(string text, List<string> keywords) => keywords.ToDictionary(k => k, _ => 1);
+    }
+
+    private class StubContextService : IKeywordContextSentimentService
+    {
+        public Dictionary<string, float> ExtractKeywordSentiments(string text, IEnumerable<string> keywords) => keywords.ToDictionary(k => k, _ => 0.5f);
+    }
+
+    [Fact]
+    public async Task AnalyzeOpinionAsync_ReturnsScores()
+    {
+        var service = new CourtOpinionAnalyzerService(new StubSentiment(), new StubExtractor(), new StubContextService());
+        var opinion = new CourtOpinion { Id = 1, CaseName = "case", PlainText = "text" };
+        var result = await service.AnalyzeOpinionAsync(opinion, new List<string> { "a" });
+
+        Assert.Equal(1.5f, result.PageSentimentScore);
+        Assert.Equal(1, result.KeywordFrequencies["a"]);
+        Assert.Equal(0.5f, result.KeywordSentimentScores["a"]);
+        Assert.Equal("text", result.RawText);
+    }
+}

--- a/RagWebScraper/Models/CourtOpinion.cs
+++ b/RagWebScraper/Models/CourtOpinion.cs
@@ -1,0 +1,22 @@
+namespace RagWebScraper.Models;
+
+/// <summary>
+/// Represents a single court opinion from the CourtListener API.
+/// </summary>
+public sealed class CourtOpinion
+{
+    /// <summary>
+    /// Opinion identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Case name for the opinion.
+    /// </summary>
+    public string CaseName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Plain text of the opinion.
+    /// </summary>
+    public string PlainText { get; set; } = string.Empty;
+}

--- a/RagWebScraper/Services/CourtListenerService.cs
+++ b/RagWebScraper/Services/CourtListenerService.cs
@@ -1,0 +1,52 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Client for retrieving court opinions from the CourtListener API.
+/// </summary>
+public sealed class CourtListenerService : ICourtListenerService
+{
+    private readonly HttpClient _httpClient;
+    private const string BaseUrl = "https://www.courtlistener.com/api/rest/v3/opinions/";
+
+    public CourtListenerService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<CourtOpinion> GetOpinionsAsync(string query, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken token = default)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            yield break;
+
+        var next = $"{BaseUrl}?search={Uri.EscapeDataString(query)}&full_case=true";
+
+        while (!string.IsNullOrEmpty(next))
+        {
+            using var response = await _httpClient.GetAsync(new Uri(next, UriKind.Absolute), token).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: token).ConfigureAwait(false);
+
+            if (doc.RootElement.TryGetProperty("results", out var results))
+            {
+                foreach (var element in results.EnumerateArray())
+                {
+                    yield return new CourtOpinion
+                    {
+                        Id = element.GetProperty("id").GetInt32(),
+                        CaseName = element.GetProperty("case_name").GetString() ?? string.Empty,
+                        PlainText = element.GetProperty("plain_text").GetString() ?? string.Empty,
+                    };
+                }
+            }
+
+            next = doc.RootElement.TryGetProperty("next", out var n) ? n.GetString() : null;
+        }
+    }
+}

--- a/RagWebScraper/Services/CourtOpinionAnalyzerService.cs
+++ b/RagWebScraper/Services/CourtOpinionAnalyzerService.cs
@@ -1,0 +1,46 @@
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Provides sentiment and keyword analysis for court opinions.
+/// </summary>
+public sealed class CourtOpinionAnalyzerService : ICourtOpinionAnalyzerService
+{
+    private readonly ISentimentAnalyzer _sentimentAnalyzer;
+    private readonly IKeywordExtractor _keywordExtractor;
+    private readonly IKeywordContextSentimentService _contextSentimentService;
+
+    public CourtOpinionAnalyzerService(
+        ISentimentAnalyzer sentimentAnalyzer,
+        IKeywordExtractor keywordExtractor,
+        IKeywordContextSentimentService contextSentimentService)
+    {
+        _sentimentAnalyzer = sentimentAnalyzer;
+        _keywordExtractor = keywordExtractor;
+        _contextSentimentService = contextSentimentService;
+    }
+
+    /// <inheritdoc />
+    public Task<AnalysisResult> AnalyzeOpinionAsync(CourtOpinion opinion, IEnumerable<string> keywords)
+    {
+        if (opinion == null)
+            throw new ArgumentNullException(nameof(opinion));
+        if (keywords == null)
+            throw new ArgumentNullException(nameof(keywords));
+
+        var text = opinion.PlainText ?? string.Empty;
+        var keywordList = keywords.ToList();
+        var result = new AnalysisResult(Enumerable.Empty<LinkedPassage>())
+        {
+            Url = opinion.CaseName,
+            PageSentimentScore = _sentimentAnalyzer.AnalyzeSentiment(text),
+            KeywordFrequencies = _keywordExtractor.ExtractKeywords(text, keywordList),
+            KeywordSentimentScores = _contextSentimentService.ExtractKeywordSentiments(text, keywordList),
+            RawText = text,
+            RawSentences = SentenceSplitter.Split(text)
+        };
+
+        return Task.FromResult(result);
+    }
+}

--- a/RagWebScraper/Services/ICourtListenerService.cs
+++ b/RagWebScraper/Services/ICourtListenerService.cs
@@ -1,0 +1,17 @@
+namespace RagWebScraper.Services;
+
+using RagWebScraper.Models;
+
+/// <summary>
+/// Downloads court opinions from the CourtListener API.
+/// </summary>
+public interface ICourtListenerService
+{
+    /// <summary>
+    /// Retrieves court opinions matching the provided query.
+    /// </summary>
+    /// <param name="query">Search query to send to the API.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>Async sequence of court opinions.</returns>
+    IAsyncEnumerable<CourtOpinion> GetOpinionsAsync(string query, CancellationToken token = default);
+}

--- a/RagWebScraper/Services/ICourtOpinionAnalyzerService.cs
+++ b/RagWebScraper/Services/ICourtOpinionAnalyzerService.cs
@@ -1,0 +1,17 @@
+namespace RagWebScraper.Services;
+
+using RagWebScraper.Models;
+
+/// <summary>
+/// Performs sentiment and keyword analysis on court opinions.
+/// </summary>
+public interface ICourtOpinionAnalyzerService
+{
+    /// <summary>
+    /// Analyzes the supplied opinion.
+    /// </summary>
+    /// <param name="opinion">Opinion to analyze.</param>
+    /// <param name="keywords">Keywords to extract statistics for.</param>
+    /// <returns>The analysis result.</returns>
+    Task<AnalysisResult> AnalyzeOpinionAsync(CourtOpinion opinion, IEnumerable<string> keywords);
+}


### PR DESCRIPTION
## Summary
- introduce `CourtListenerService` for streaming CourtListener JSON opinions
- add `CourtOpinionAnalyzerService` for sentiment and keyword analysis of opinions
- define `CourtOpinion` model and service interfaces
- include unit tests for new services

## Testing
- `dotnet build RagWebScraper.sln -c Debug`
- `dotnet test RagWebScraper.Tests/RagWebScraper.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6851a366a4f4832c89c8098e92bad5c1