### PR TITLE
Enable local CourtListener JSON ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project implements a sentiment-aware **Retrieval-Augmented Generation (RAG)
 
 ## Features
 
-* **Ingest from URLs or PDFs**
+* **Ingest from URLs, PDFs, or CourtListener JSON files**
 * **Local Sentiment Analysis** using ONNX model and ML.NET
 * **Keyword Frequency & Context Sentiment Extraction**
 * **Vector Embedding with OpenAI**
@@ -89,6 +89,11 @@ All major services and controllers include XML documentation comments. IntelliSe
 2. Enter keywords
 3. Select one or more PDFs
 4. Analyze and review results & charts
+
+### Import CourtListener JSON
+
+1. Place your downloaded CourtListener JSON on disk
+2. Provide the path to `ICourtListenerService.GetOpinionsAsync`
 
 ### Query RAG
 

--- a/RagWebScraper.Tests/FileCourtListenerServiceTests.cs
+++ b/RagWebScraper.Tests/FileCourtListenerServiceTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class FileCourtListenerServiceTests
+{
+    [Fact]
+    public async Task GetOpinionsAsync_ReadsOpinionsFromFile()
+    {
+        var data = new
+        {
+            results = new[]
+            {
+                new { id = 1, case_name = "a", plain_text = "A" },
+                new { id = 2, case_name = "b", plain_text = "B" }
+            }
+        };
+
+        var file = Path.GetTempFileName();
+        await File.WriteAllTextAsync(file, JsonSerializer.Serialize(data));
+
+        var service = new FileCourtListenerService();
+        var opinions = new List<CourtOpinion>();
+        await foreach (var op in service.GetOpinionsAsync(file))
+        {
+            opinions.Add(op);
+        }
+
+        File.Delete(file);
+
+        Assert.Equal(2, opinions.Count);
+        Assert.Equal("a", opinions[0].CaseName);
+        Assert.Equal("B", opinions[1].PlainText);
+    }
+}

--- a/RagWebScraper/Program.cs
+++ b/RagWebScraper/Program.cs
@@ -61,6 +61,7 @@ builder.Services.AddSingleton<IRagAnalysisQueue, RagAnalysisQueue>();
 builder.Services.AddHostedService<RagAnalysisWorker>();
 builder.Services.AddSingleton<IRagQueryQueue, RagQueryQueue>();
 builder.Services.AddHostedService<RagQueryWorker>();
+builder.Services.AddSingleton<ICourtListenerService, FileCourtListenerService>();
 
 // Analysis / AI
 builder.Services.AddSingleton<ISentimentAnalyzer, SentimentAnalyzerService>();

--- a/RagWebScraper/Services/FileCourtListenerService.cs
+++ b/RagWebScraper/Services/FileCourtListenerService.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using RagWebScraper.Models;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Loads <see cref="CourtOpinion"/> instances from local CourtListener JSON files.
+/// </summary>
+public sealed class FileCourtListenerService : ICourtListenerService
+{
+    /// <inheritdoc />
+    public async IAsyncEnumerable<CourtOpinion> GetOpinionsAsync(string filePath, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken token = default)
+    {
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+            yield break;
+
+        await using var stream = File.OpenRead(filePath);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+        if (!doc.RootElement.TryGetProperty("results", out var results))
+            yield break;
+
+        foreach (var element in results.EnumerateArray())
+        {
+            token.ThrowIfCancellationRequested();
+            yield return new CourtOpinion
+            {
+                Id = element.GetProperty("id").GetInt32(),
+                CaseName = element.GetProperty("case_name").GetString() ?? string.Empty,
+                PlainText = element.GetProperty("plain_text").GetString() ?? string.Empty
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse CourtListener JSON files locally with `FileCourtListenerService`
- register new service in the DI container
- add docs on CourtListener JSON ingestion
- test reading court opinions from a JSON file

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6851c8ca05f8832c9d11985737dbfcc0