### PR TITLE
Add CourtListener JSON upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ All major services and controllers include XML documentation comments. IntelliSe
 
 ### Import CourtListener JSON
 
-1. Place your downloaded CourtListener JSON on disk
-2. Provide the path to `ICourtListenerService.GetOpinionsAsync`
+1. Navigate to `/upload-json`
+2. Enter keywords to analyze
+3. Select one or more CourtListener JSON files
+4. Press **Upload** and review the sentiment and keyword charts
 
 ### Query RAG
 

--- a/RagWebScraper/Controllers/CourtListenerUploadController.cs
+++ b/RagWebScraper/Controllers/CourtListenerUploadController.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+
+namespace RagWebScraper.Controllers;
+
+/// <summary>
+/// Accepts CourtListener JSON uploads and returns analysis results.
+/// </summary>
+[ApiController]
+[Route("api/courtlistener")]
+public class CourtListenerUploadController : ControllerBase
+{
+    private readonly ICourtListenerService _loader;
+    private readonly ICourtOpinionAnalyzerService _analyzer;
+
+    public CourtListenerUploadController(ICourtListenerService loader, ICourtOpinionAnalyzerService analyzer)
+    {
+        _loader = loader;
+        _analyzer = analyzer;
+    }
+
+    [HttpPost("analyze")]
+    public async Task<ActionResult<List<AnalysisResult>>> Analyze([FromForm] IFormFileCollection files, [FromForm] string keywords, CancellationToken token)
+    {
+        if (files == null || files.Count == 0)
+            return BadRequest("No files uploaded.");
+
+        var keywordList = keywords?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+        var results = new List<AnalysisResult>();
+
+        foreach (var file in files)
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}_{file.FileName}");
+            await using (var fs = new FileStream(tempPath, FileMode.Create, FileAccess.Write))
+            {
+                await file.CopyToAsync(fs, token);
+            }
+
+            await foreach (var opinion in _loader.GetOpinionsAsync(tempPath, token))
+            {
+                var result = await _analyzer.AnalyzeOpinionAsync(opinion, keywordList);
+                result.FileName = $"{opinion.CaseName} ({opinion.Id})";
+                results.Add(result);
+            }
+
+            System.IO.File.Delete(tempPath);
+        }
+
+        return Ok(results);
+    }
+}

--- a/RagWebScraper/Pages/UploadJson.razor
+++ b/RagWebScraper/Pages/UploadJson.razor
@@ -1,0 +1,104 @@
+@page "/upload-json"
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@inject AppStateService AppState
+@inject IJSRuntime JS
+
+@using RagWebScraper.Models
+
+<h3 class="mb-3 text-primary">Upload CourtListener JSON</h3>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <div class="mb-3">
+            <label class="form-label fw-bold">Enter search keywords (comma-separated):</label>
+            <input type="text" class="form-control" @bind="searchTerms" />
+        </div>
+
+        <InputFile OnChange="HandleUpload" multiple accept=".json" />
+        @if (!string.IsNullOrWhiteSpace(uploadStatus))
+        {
+            <p class="text-success">@uploadStatus</p>
+        }
+    </div>
+</div>
+
+@if (AppState.CourtListenerAnalysisResults?.Any() == true)
+{
+    <h3 class="text-success">JSON Analysis Results</h3>
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <PageSentimentChart Results="AppState.CourtListenerAnalysisResults" Display="true" />
+        </div>
+        <div class="col-md-6">
+            <KeywordSentimentChart Results="AppState.CourtListenerAnalysisResults" Display="true" />
+        </div>
+    </div>
+
+    @foreach (var result in AppState.CourtListenerAnalysisResults)
+    {
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5>@result.FileName</h5>
+                <p>
+                    Page Sentiment Score:
+                    <span class="badge bg-primary">@result.PageSentimentScore</span>
+                </p>
+                @if (result.KeywordSentimentScores?.Any() == true)
+                {
+                    <h6>Keyword Sentiments:</h6>
+                    <ul>
+                        @foreach (var kv in result.KeywordSentimentScores)
+                        {
+                            <li>
+                                <strong>@kv.Key</strong> :
+                                <span class="badge bg-success">@kv.Value</span>
+                            </li>
+                        }
+                    </ul>
+                }
+                @if (result.KeywordFrequencies?.Count > 0)
+                {
+                    <KeywordChart Frequencies="@result.KeywordFrequencies" />
+                }
+            </div>
+        </div>
+    }
+}
+
+@code {
+    private string searchTerms = string.Empty;
+    private string? uploadStatus;
+
+    private async Task HandleUpload(InputFileChangeEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(searchTerms))
+        {
+            uploadStatus = "Please provide keywords before uploading.";
+            return;
+        }
+
+        var form = new MultipartFormDataContent();
+        foreach (var file in e.GetMultipleFiles())
+        {
+            var stream = file.OpenReadStream();
+            var content = new StreamContent(stream);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(file.ContentType);
+            form.Add(content, "files", file.Name);
+        }
+        form.Add(new StringContent(searchTerms), "keywords");
+
+        var apiUrl = Navigation.BaseUri + "api/courtlistener/analyze";
+        var response = await Http.PostAsync(apiUrl, form);
+        if (response.IsSuccessStatusCode)
+        {
+            var results = await response.Content.ReadFromJsonAsync<List<AnalysisResult>>() ?? [];
+            AppState.SetCourtListenerResults(results);
+            uploadStatus = "JSON files analyzed.";
+        }
+        else
+        {
+            uploadStatus = $"Upload failed: {response.ReasonPhrase}";
+        }
+    }
+}

--- a/RagWebScraper/Program.cs
+++ b/RagWebScraper/Program.cs
@@ -70,6 +70,7 @@ builder.Services.AddSingleton<IKeywordContextSentimentService, KeywordContextSen
 builder.Services.AddSingleton<KeywordSentimentSummaryService>();
 builder.Services.AddSingleton<IPageAnalyzerService, PageAnalyzerService>();
 builder.Services.AddSingleton<IDocumentClusterer, TfidfKMeansClusterer>();
+builder.Services.AddSingleton<ICourtOpinionAnalyzerService, CourtOpinionAnalyzerService>();
 
 // Scoped / Page-bound
 builder.Services.AddScoped<IAnalysisService, PdfAnalysisService>();

--- a/RagWebScraper/Shared/AppStateService.cs
+++ b/RagWebScraper/Shared/AppStateService.cs
@@ -8,6 +8,7 @@ public class AppStateService
     public List<AnalysisResult> UrlAnalysisResults { get; private set; } = new();
 
     public List<AnalysisResult> PdfAnalysisResults { get; private set; } = new();
+    public List<AnalysisResult> CourtListenerAnalysisResults { get; private set; } = new();
     public List<EntityGraph> EntityGraphs { get; private set; } = new();
 
     public string PdfKeywordSummary { get; private set; } = string.Empty;
@@ -72,12 +73,18 @@ public class AppStateService
         NotifyStateChanged();
     }
 
+    public void SetCourtListenerResults(List<AnalysisResult> results)
+    {
+        CourtListenerAnalysisResults = results;
+        NotifyStateChanged();
+    }
+
     public void SetPdfKeywordSummary(string summary)
     {
         PdfKeywordSummary = summary;
         NotifyStateChanged();
     }
-       
+
     public void SetUrlKeywordSummary(string summary)
     {
         UrlKeywordSummary = summary;

--- a/RagWebScraper/Shared/NavMenu.razor
+++ b/RagWebScraper/Shared/NavMenu.razor
@@ -22,6 +22,11 @@
                     </NavLink>
                 </li>
                 <li class="nav-item">
+                    <NavLink class="nav-link" href="upload-json">
+                        <span class="oi oi-cloud-upload" aria-hidden="true"></span> 📑 Upload JSON
+                    </NavLink>
+                </li>
+                <li class="nav-item">
                     <NavLink class="nav-link" href="pdf-scraper" Match="NavLinkMatch.All">
                         <span class="oi oi-file" aria-hidden="true"></span> 📑 PDF Scraper
                     </NavLink>


### PR DESCRIPTION
## Summary
- add upload-json page and nav link
- implement controller for JSON upload analysis
- track CourtListener results in app state
- register CourtOpinionAnalyzerService
- clarify README instructions for CourtListener JSON uploads

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6851d0593d48832c94d331880ddbf16a