### PR TITLE
Add JSON ingestion component

### DIFF
--- a/RagWebScraper/Controllers/JsonUploadController.cs
+++ b/RagWebScraper/Controllers/JsonUploadController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using RagWebScraper.Services;
+
+namespace RagWebScraper.Controllers;
+
+/// <summary>
+/// API controller for uploading JSON files and ingesting their content into the RAG vector store.
+/// </summary>
+[ApiController]
+[Route("api/json-ingest")]
+public class JsonUploadController : ControllerBase
+{
+    private readonly IJsonIngestService _ingestService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonUploadController"/> class.
+    /// </summary>
+    public JsonUploadController(IJsonIngestService ingestService)
+    {
+        _ingestService = ingestService;
+    }
+
+    /// <summary>
+    /// Uploads one or more JSON files and ingests their content.
+    /// </summary>
+    /// <param name="files">The uploaded JSON files.</param>
+    /// <param name="token">Cancellation token.</param>
+    [HttpPost("upload")]
+    public async Task<IActionResult> Upload([FromForm] IFormFileCollection files, CancellationToken token)
+    {
+        if (files == null || files.Count == 0)
+            return BadRequest("No files uploaded.");
+
+        foreach (var file in files)
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}_{file.FileName}");
+            await using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            {
+                await file.CopyToAsync(fs, token);
+            }
+
+            await _ingestService.IngestAsync(path, token);
+            System.IO.File.Delete(path);
+        }
+
+        return Ok(new { Message = "Files ingested." });
+    }
+}

--- a/RagWebScraper/Pages/JsonIngest.razor
+++ b/RagWebScraper/Pages/JsonIngest.razor
@@ -1,0 +1,34 @@
+@page "/json-ingest"
+@inject HttpClient Http
+@inject NavigationManager Nav
+
+<h3 class="mb-3 text-primary">Upload JSON for Ingestion</h3>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <InputFile OnChange="HandleUpload" multiple accept=".json" />
+        @if (!string.IsNullOrWhiteSpace(status))
+        {
+            <p class="text-success">@status</p>
+        }
+    </div>
+</div>
+
+@code {
+    private string? status;
+
+    private async Task HandleUpload(InputFileChangeEventArgs e)
+    {
+        var form = new MultipartFormDataContent();
+        foreach (var file in e.GetMultipleFiles())
+        {
+            var stream = file.OpenReadStream();
+            var content = new StreamContent(stream);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(file.ContentType);
+            form.Add(content, "files", file.Name);
+        }
+
+        var response = await Http.PostAsync(Nav.BaseUri + "api/json-ingest/upload", form);
+        status = response.IsSuccessStatusCode ? "JSON files ingested." : $"Upload failed: {response.ReasonPhrase}";
+    }
+}

--- a/RagWebScraper/Program.cs
+++ b/RagWebScraper/Program.cs
@@ -71,6 +71,7 @@ builder.Services.AddSingleton<KeywordSentimentSummaryService>();
 builder.Services.AddSingleton<IPageAnalyzerService, PageAnalyzerService>();
 builder.Services.AddSingleton<IDocumentClusterer, TfidfKMeansClusterer>();
 builder.Services.AddSingleton<ICourtOpinionAnalyzerService, CourtOpinionAnalyzerService>();
+builder.Services.AddSingleton<IJsonIngestService, JsonIngestService>();
 
 // Scoped / Page-bound
 builder.Services.AddScoped<IAnalysisService, PdfAnalysisService>();

--- a/RagWebScraper/Services/JsonIngestService.cs
+++ b/RagWebScraper/Services/JsonIngestService.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Service that parses uploaded JSON files and ingests the contained text into the vector database.
+/// </summary>
+public interface IJsonIngestService
+{
+    /// <summary>
+    /// Parses the JSON file and ingests its text content.
+    /// Each element should contain a <c>text</c> property and optional <c>id</c>.
+    /// </summary>
+    /// <param name="filePath">Path to the JSON file.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task IngestAsync(string filePath, CancellationToken token = default);
+}
+
+/// <inheritdoc cref="IJsonIngestService"/>
+public sealed class JsonIngestService : IJsonIngestService
+{
+    private readonly IChunkIngestorService _ingestor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonIngestService"/> class.
+    /// </summary>
+    public JsonIngestService(IChunkIngestorService ingestor)
+    {
+        _ingestor = ingestor;
+    }
+
+    /// <inheritdoc />
+    public async Task IngestAsync(string filePath, CancellationToken token = default)
+    {
+        if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+            return;
+
+        await using var stream = File.OpenRead(filePath);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            return;
+
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            token.ThrowIfCancellationRequested();
+
+            if (!element.TryGetProperty("text", out var textProp))
+                continue;
+
+            var text = textProp.GetString();
+            if (string.IsNullOrWhiteSpace(text))
+                continue;
+
+            var id = element.TryGetProperty("id", out var idProp)
+                ? idProp.GetString() ?? Guid.NewGuid().ToString()
+                : Guid.NewGuid().ToString();
+
+            await _ingestor.IngestChunksAsync(id, text);
+        }
+    }
+}

--- a/RagWebScraper/Shared/NavMenu.razor
+++ b/RagWebScraper/Shared/NavMenu.razor
@@ -27,6 +27,11 @@
                     </NavLink>
                 </li>
                 <li class="nav-item">
+                    <NavLink class="nav-link" href="json-ingest">
+                        <span class="oi oi-cloud-upload" aria-hidden="true"></span> 🗄️ Ingest JSON
+                    </NavLink>
+                </li>
+                <li class="nav-item">
                     <NavLink class="nav-link" href="pdf-scraper" Match="NavLinkMatch.All">
                         <span class="oi oi-file" aria-hidden="true"></span> 📑 PDF Scraper
                     </NavLink>


### PR DESCRIPTION
## Summary
- create `IJsonIngestService` and `JsonIngestService` for parsing generic JSON files and ingesting into the vector store
- expose new ingestion endpoint via `JsonUploadController`
- add Blazor page `JsonIngest.razor` to upload JSON files
- register the service in DI and add navigation link

## Testing
- `dotnet format --no-restore`
- `dotnet build RagWebScraper.sln -v minimal`
- `dotnet test RagWebScraper.sln --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68573330b324832cbfb8b2935b3dca4a