### PR TITLE
Enable directory uploads for JSON ingest

### DIFF
--- a/RagWebScraper/Controllers/JsonUploadController.cs
+++ b/RagWebScraper/Controllers/JsonUploadController.cs
@@ -33,7 +33,8 @@ public class JsonUploadController : ControllerBase
 
         foreach (var file in files)
         {
-            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}_{file.FileName}");
+            var safeName = Path.GetFileName(file.FileName);
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}_{safeName}");
             await using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
             {
                 await file.CopyToAsync(fs, token);

--- a/RagWebScraper/Pages/JsonIngest.razor
+++ b/RagWebScraper/Pages/JsonIngest.razor
@@ -6,7 +6,7 @@
 
 <div class="card shadow-sm mb-4">
     <div class="card-body">
-        <InputFile OnChange="HandleUpload" multiple accept=".json" />
+        <InputFile OnChange="HandleUpload" multiple accept=".json" webkitdirectory directory />
         @if (!string.IsNullOrWhiteSpace(status))
         {
             <p class="text-success">@status</p>

--- a/RagWebScraper/Pages/UploadJson.razor
+++ b/RagWebScraper/Pages/UploadJson.razor
@@ -15,7 +15,7 @@
             <input type="text" class="form-control" @bind="searchTerms" />
         </div>
 
-        <InputFile OnChange="HandleUpload" multiple accept=".json" />
+        <InputFile OnChange="HandleUpload" multiple accept=".json" webkitdirectory directory />
         @if (!string.IsNullOrWhiteSpace(uploadStatus))
         {
             <p class="text-success">@uploadStatus</p>


### PR DESCRIPTION
## Summary
- support uploading an entire directory of JSON files on the new ingest and analysis pages
- sanitize uploaded JSON file names on the server

## Testing
- `dotnet test --no-build` *(fails: SDK attempted to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68577f5ff174832ca354e5d0aa13e719