### PR TITLE
Enable manual cross link analysis

### DIFF
--- a/RagWebScraper/Pages/CrossDocLinksPage.razor
+++ b/RagWebScraper/Pages/CrossDocLinksPage.razor
@@ -17,14 +17,14 @@
         Generating links...
     </p>
 }
-else if (!AppState.AllCrossDocLinks.Any() &&
-         !AppState.PdfCrossDocLinks.Any() &&
-         !AppState.UrlCrossDocLinks.Any())
+else if (!AppState.UrlAnalysisResults.Any() && !AppState.PdfAnalysisResults.Any())
 {
-    <p>No cross-document links available. Please analyze some documents first.</p>
+    <p>No documents analyzed yet. Please analyze some documents first.</p>
 }
 else
 {
+    <button class="btn btn-primary mb-3" @onclick="GenerateLinksAsync">Start Cross Link Analysis</button>
+
     if (AppState.AllCrossDocLinks.Any())
     {
         <h4 class="mt-3">All Documents</h4>
@@ -45,27 +45,33 @@ else
 }
 
 @code {
-    private bool _isLoading = true;
+    private bool _isLoading;
 
     protected override void OnInitialized()
     {
         AppState.OnChange += StateHasChanged;
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await GenerateLinksAsync();
-        }
-    }
-
     private async Task GenerateLinksAsync()
     {
-        var links = await CombinedLinkService.ComputeLinksAsync(
+        _isLoading = true;
+        StateHasChanged();
+
+        var urlLinks = await CombinedLinkService.ComputeLinksAsync(
+            AppState.UrlAnalysisResults,
+            Enumerable.Empty<AnalysisResult>());
+        AppState.SetUrlCrossDocLinks(urlLinks);
+
+        var pdfLinks = await CombinedLinkService.ComputeLinksAsync(
+            Enumerable.Empty<AnalysisResult>(),
+            AppState.PdfAnalysisResults);
+        AppState.SetPdfCrossDocLinks(pdfLinks);
+
+        var allLinks = await CombinedLinkService.ComputeLinksAsync(
             AppState.UrlAnalysisResults,
             AppState.PdfAnalysisResults);
-        AppState.SetAllCrossDocLinks(links);
+        AppState.SetAllCrossDocLinks(allLinks);
+
         _isLoading = false;
         StateHasChanged();
     }

--- a/RagWebScraper/Pages/RAGAnalyzer.razor
+++ b/RagWebScraper/Pages/RAGAnalyzer.razor
@@ -3,9 +3,7 @@
 @inject NavigationManager Navigation
 @inject KeywordSentimentSummaryService SummaryService
 @inject AppStateService AppState
-@inject IRagAnalyzerService RagAnalyzer
-@inject TextChunker Chunker
-@inject CombinedCrossDocLinkService CombinedLinkService
+
 @using System.Text
 @inject ICsvExportService CsvExporter
 @inject IJSRuntime JS
@@ -47,13 +45,8 @@
             <input class="form-check-input" type="checkbox" id="toggleKeyword" @bind="showKeyword" />
             <label class="form-check-label" for="toggleKeyword">Show Keyword Chart</label>
         </div>
-        <div class="form-check form-check-inline">
-            <input class="form-check-input" type="checkbox" id="toggleLinks" @bind="showLinks" />
-            <label class="form-check-label" for="toggleLinks">Show Cross Links</label>
-        </div>
         <button class="btn btn-sm btn-secondary ms-3" @onclick="DownloadPageSentimentCsv">Download Sentiment CSV</button>
         <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadKeywordCsv">Download Keyword CSV</button>
-        <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadLinksCsv">Download Links CSV</button>
     </div>
     <div class="col-md-6">
         @if (!string.IsNullOrWhiteSpace(AppState.UrlKeywordSummary))
@@ -72,12 +65,6 @@
             <KeywordSentimentChart Results="AppState.UrlAnalysisResults" Display="showKeyword" />
         </div>
     </div>
-
-    @if (AppState.UrlCrossDocLinks?.Any() == true)
-    {
-        <h3 class="text-primary">Cross-Document Semantic Links</h3>
-        <CrossDocLinks Links="AppState.UrlCrossDocLinks" Display="showLinks" />
-    }
 
     <Virtualize Items="AppState.UrlAnalysisResults" Context="res">
         <div class="card mb-3">
@@ -110,7 +97,6 @@
     private string searchTerms;
     private bool showSentiment = true;
     private bool showKeyword = true;
-    private bool showLinks = true;
 
     private async Task SubmitForAnalysis()
     {
@@ -138,22 +124,7 @@
 
         AppState.SetUrlResults(result);
 
-        if (result.Count > 1)
-        {
-            var docs = result.Select(r => new AnalyzedDocument(
-                r.Url,
-                Chunker.ChunkText(r.RawText)
-                    .Select(t => new DocumentChunk(r.Url, t))
-                    .ToList())).ToList();
-            var set = new DocumentSet(docs);
-            var analysis = await RagAnalyzer.AnalyzeAsync(set);
-            AppState.SetUrlCrossDocLinks(analysis.Links.ToList());
-        }
 
-        var combined = await CombinedLinkService.ComputeLinksAsync(
-            result,
-            AppState.PdfAnalysisResults);
-        AppState.SetAllCrossDocLinks(combined);
 
         // Generate and store summary
         var summary = await SummaryService.GenerateSummaryAsync(result);
@@ -182,16 +153,6 @@
         await JS.InvokeVoidAsync("downloadFile", fileName, content);
     }
 
-    private async Task DownloadLinksCsv()
-    {
-        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for cross links CSV", "cross_links");
-        if (string.IsNullOrWhiteSpace(baseName))
-            baseName = "cross_links";
-        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
-        var bytes = CsvExporter.ExportCrossLinks(AppState.UrlCrossDocLinks);
-        var content = Encoding.UTF8.GetString(bytes);
-        await JS.InvokeVoidAsync("downloadFile", fileName, content);
-    }
 
     protected override void OnInitialized()
     {

--- a/RagWebScraper/Pages/UploadPdf.razor
+++ b/RagWebScraper/Pages/UploadPdf.razor
@@ -2,9 +2,6 @@
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject AppStateService AppState
-@inject IRagAnalyzerService RagAnalyzer
-@inject TextChunker Chunker
-@inject CombinedCrossDocLinkService CombinedLinkService
 @inject KeywordSentimentSummaryService SummaryService
 @inject ICsvExportService CsvExporter
 @inject IJSRuntime JS
@@ -47,21 +44,10 @@
             <input class="form-check-input" type="checkbox" id="togglePdfKeyword" @bind="showKeyword" />
             <label class="form-check-label" for="togglePdfKeyword">Show Keyword Chart</label>
         </div>
-        <div class="form-check form-check-inline">
-            <input class="form-check-input" type="checkbox" id="togglePdfLinks" @bind="showLinks" />
-            <label class="form-check-label" for="togglePdfLinks">Show Cross Links</label>
-        </div>
         <button class="btn btn-sm btn-secondary ms-3" @onclick="DownloadPageSentimentCsv">Download Sentiment CSV</button>
         <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadKeywordCsv">Download Keyword CSV</button>
-        <button class="btn btn-sm btn-secondary ms-1" @onclick="DownloadLinksCsv">Download Links CSV</button>
     </div>
-    <div class="col-md-6">
-        @if (AppState.PdfCrossDocLinks?.Any() == true)
-        {
-            <h3 class="text-primary">Cross-Document Semantic Links</h3>
-            <CrossDocLinks Links="AppState.PdfCrossDocLinks" Display="showLinks" />
-        }
-    </div>
+    
     <div class="col-md-6">
         @if (!string.IsNullOrWhiteSpace(AppState.PdfKeywordSummary))
         {
@@ -126,7 +112,6 @@
     private string searchTerms = string.Empty;
     private bool showSentiment = true;
     private bool showKeyword = true;
-    private bool showLinks = true;
 
     private Timer? _pollingTimer;
     private List<string> uploadedFileNames = new();
@@ -208,22 +193,7 @@
                     }
 
 
-                    if (results.Count > 1)
-                    {
-                        var docs = results.Select(r => new AnalyzedDocument(
-                            r.FileName,
-                            Chunker.ChunkText(r.RawText)
-                                .Select(t => new DocumentChunk(r.FileName, t))
-                                .ToList())).ToList();
-                        var set = new DocumentSet(docs);
-                        var analysis = await RagAnalyzer.AnalyzeAsync(set);
-                        AppState.SetPdfCrossDocLinks(analysis.Links.ToList());
-                    }
 
-                    var combined = await CombinedLinkService.ComputeLinksAsync(
-                        AppState.UrlAnalysisResults,
-                        results);
-                    AppState.SetAllCrossDocLinks(combined);
 
                     _pollingTimer?.Stop();
                     _pollingTimer?.Dispose();
@@ -263,16 +233,6 @@
         await JS.InvokeVoidAsync("downloadFile", fileName, content);
     }
 
-    private async Task DownloadLinksCsv()
-    {
-        var baseName = await JS.InvokeAsync<string>("prompt", "Enter file name for cross links CSV", "cross_links");
-        if (string.IsNullOrWhiteSpace(baseName))
-            baseName = "cross_links";
-        var fileName = $"{baseName}_{DateTime.Now:ddMMyyyyHHmmss}.csv";
-        var bytes = CsvExporter.ExportCrossLinks(AppState.PdfCrossDocLinks);
-        var content = Encoding.UTF8.GetString(bytes);
-        await JS.InvokeVoidAsync("downloadFile", fileName, content);
-    }
 
     protected override void OnInitialized()
     {


### PR DESCRIPTION
## Summary
- simplify UploadPdf and RAGAnalyzer pages by removing automatic cross-link generation
- add manual cross-link analysis button on the Cross Links page
- compute cross links on demand only when requested

## Testing
- `dotnet build`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6859be4ad2a0832ca9d7384a8f179a05