### PR TITLE
Add RAG research agent

### DIFF
--- a/RagWebScraper.Tests/RagResearchAgentTests.cs
+++ b/RagWebScraper.Tests/RagResearchAgentTests.cs
@@ -1,0 +1,56 @@
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class RagResearchAgentTests
+{
+    private class StubEmbedding : IEmbeddingService
+    {
+        public Task<List<float>> GetEmbeddingAsync(string input) => Task.FromResult(new List<float> { 0.1f });
+        public Task<List<float[]>> GetEmbeddingsAsync(IEnumerable<string> inputs) => Task.FromResult(new List<float[]> ());
+    }
+
+    private class StubVectorStore : IVectorStoreService
+    {
+        public List<QdrantResult> Results { get; init; } = new();
+        public Task UpsertVectorAsync(VectorData vectorData) => Task.CompletedTask;
+        public Task<List<QdrantResult>> QueryAsync(List<float> embedding, int topK = 3) => Task.FromResult(Results);
+    }
+
+    private class StubChat : IChatCompletionService
+    {
+        public string? Prompt { get; private set; }
+        public string Response { get; init; } = "stub";
+        public Task<string> GetCompletionAsync(string systemPrompt, string userPrompt)
+        {
+            Prompt = userPrompt;
+            return Task.FromResult(Response);
+        }
+    }
+
+    [Fact]
+    public async Task ResearchAsync_ReturnsMessage_WhenNoResults()
+    {
+        var agent = new RagResearchAgent(new StubEmbedding(), new StubVectorStore(), new StubChat());
+        var result = await agent.ResearchAsync("test");
+        Assert.Equal("No relevant documents found.", result);
+    }
+
+    [Fact]
+    public async Task ResearchAsync_UsesChatService()
+    {
+        var store = new StubVectorStore
+        {
+            Results = new List<QdrantResult>
+            {
+                new QdrantResult{ payload = new Dictionary<string, object>{{"ChunkText","A"}}, score = 0.9f }
+            }
+        };
+        var chat = new StubChat { Response = "analysis" };
+        var agent = new RagResearchAgent(new StubEmbedding(), store, chat);
+        var result = await agent.ResearchAsync("test");
+        Assert.Equal("analysis", result);
+        Assert.Contains("A", chat.Prompt!);
+    }
+}

--- a/RagWebScraper/Controllers/PdfUploadController.cs
+++ b/RagWebScraper/Controllers/PdfUploadController.cs
@@ -17,7 +17,7 @@ public class PdfUploadController : ControllerBase
     private readonly ISentimentAnalyzer _sentiment;
     private readonly TextChunker _chunker;
     private readonly IEmbeddingService _embedding;
-    private readonly VectorStoreService _store;
+    private readonly IVectorStoreService _store;
     private readonly IKeywordExtractor _keywordExtractor;
     private readonly IKeywordContextSentimentService _keywordContextSentimentService;
     private readonly IChunkIngestorService _chunkIngestor;
@@ -31,7 +31,7 @@ public class PdfUploadController : ControllerBase
         ISentimentAnalyzer sentiment,
         TextChunker chunker,
         IEmbeddingService embedding,
-        VectorStoreService store,
+        IVectorStoreService store,
         IKeywordExtractor keywordExtractor,
         IKeywordContextSentimentService keywordContextSentimentService,
         IChunkIngestorService chunkIngestor,

--- a/RagWebScraper/Pages/RAGQuery.razor
+++ b/RagWebScraper/Pages/RAGQuery.razor
@@ -3,7 +3,7 @@
 @using RagWebScraper.Services
 @using static System.Net.WebRequestMethods
 @inject IEmbeddingService EmbeddingService
-@inject VectorStoreService VectorStoreService
+@inject IVectorStoreService VectorStoreService
 @inject HttpClient Http
 @inject NavigationManager Navigation
 

--- a/RagWebScraper/Program.cs
+++ b/RagWebScraper/Program.cs
@@ -68,6 +68,7 @@ builder.Services.AddSingleton<ISentimentAnalyzer, SentimentAnalyzerService>();
 builder.Services.AddSingleton<IKeywordExtractor, KeywordExtractorService>();
 builder.Services.AddSingleton<IKeywordContextSentimentService, KeywordContextSentimentService>();
 builder.Services.AddSingleton<KeywordSentimentSummaryService>();
+builder.Services.AddSingleton<IChatCompletionService, OpenAIChatCompletionService>();
 builder.Services.AddSingleton<IPageAnalyzerService, PageAnalyzerService>();
 builder.Services.AddSingleton<IDocumentClusterer, TfidfKMeansClusterer>();
 builder.Services.AddSingleton<ICourtOpinionAnalyzerService, CourtOpinionAnalyzerService>();
@@ -76,6 +77,7 @@ builder.Services.AddSingleton<IJsonIngestService, JsonIngestService>();
 // Scoped / Page-bound
 builder.Services.AddScoped<IAnalysisService, PdfAnalysisService>();
 builder.Services.AddScoped<IRagAnalyzerService, RagAnalyzerService>();
+builder.Services.AddScoped<IRagResearchAgent, RagResearchAgent>();
 builder.Services.AddScoped<IKnowledgeGraphService, KnowledgeGraphService>();
 builder.Services.AddScoped<IEntityGraphExtractor, SpaceEntityGraphExtractor>();
 builder.Services.AddScoped<ICrossDocumentLinker, SemanticCrossLinker>();
@@ -85,7 +87,7 @@ builder.Services.AddScoped<CombinedCrossDocLinkService>();
 // HttpClients
 // ---------------------------------------------
 builder.Services.AddHttpClient<IWebScraperService, WebScraperService>();
-builder.Services.AddHttpClient<VectorStoreService>();
+builder.Services.AddHttpClient<IVectorStoreService, VectorStoreService>();
 builder.Services.AddHttpClient<QdrantSetupService>();
 builder.Services.AddHttpClient<IPdfScraperService, PdfScraperService>();
 

--- a/RagWebScraper/Services/ChunkIngestorService.cs
+++ b/RagWebScraper/Services/ChunkIngestorService.cs
@@ -18,9 +18,9 @@ public class ChunkIngestorService : IChunkIngestorService
 {
     private readonly TextChunker _chunker;
     private readonly IEmbeddingService _embeddingService;
-    private readonly VectorStoreService _vectorStore;
+    private readonly IVectorStoreService _vectorStore;
 
-    public ChunkIngestorService(TextChunker chunker, IEmbeddingService embedding, VectorStoreService vectorStore)
+    public ChunkIngestorService(TextChunker chunker, IEmbeddingService embedding, IVectorStoreService vectorStore)
     {
         _chunker = chunker;
         _embeddingService = embedding;

--- a/RagWebScraper/Services/IChatCompletionService.cs
+++ b/RagWebScraper/Services/IChatCompletionService.cs
@@ -1,0 +1,9 @@
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Provides LLM chat completion functionality.
+/// </summary>
+public interface IChatCompletionService
+{
+    Task<string> GetCompletionAsync(string systemPrompt, string userPrompt);
+}

--- a/RagWebScraper/Services/IRagResearchAgent.cs
+++ b/RagWebScraper/Services/IRagResearchAgent.cs
@@ -1,0 +1,14 @@
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Provides expert RAG analysis capabilities.
+/// </summary>
+public interface IRagResearchAgent
+{
+    /// <summary>
+    /// Executes a research query across ingested documents and highlights nuanced differences.
+    /// </summary>
+    /// <param name="query">The user's research question.</param>
+    /// <returns>A natural language summary of findings.</returns>
+    Task<string> ResearchAsync(string query);
+}

--- a/RagWebScraper/Services/IVectorStoreService.cs
+++ b/RagWebScraper/Services/IVectorStoreService.cs
@@ -1,0 +1,10 @@
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Abstraction over the vector database.
+/// </summary>
+public interface IVectorStoreService
+{
+    Task UpsertVectorAsync(VectorData vectorData);
+    Task<List<QdrantResult>> QueryAsync(List<float> embedding, int topK = 3);
+}

--- a/RagWebScraper/Services/OpenAIChatCompletionService.cs
+++ b/RagWebScraper/Services/OpenAIChatCompletionService.cs
@@ -1,0 +1,29 @@
+using OpenAI;
+using OpenAI.Chat;
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// OpenAI-based implementation of <see cref="IChatCompletionService"/>.
+/// </summary>
+public sealed class OpenAIChatCompletionService : IChatCompletionService
+{
+    private readonly OpenAIClient _client;
+
+    public OpenAIChatCompletionService(OpenAIClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<string> GetCompletionAsync(string systemPrompt, string userPrompt)
+    {
+        var chat = _client.GetChatClient("gpt-4");
+        var messages = new List<ChatMessage>
+        {
+            ChatMessage.CreateSystemMessage(systemPrompt),
+            ChatMessage.CreateUserMessage(userPrompt)
+        };
+        ChatCompletion response = await chat.CompleteChatAsync(messages);
+        return response.Content[0].Text ?? string.Empty;
+    }
+}

--- a/RagWebScraper/Services/RagQueryWorker.cs
+++ b/RagWebScraper/Services/RagQueryWorker.cs
@@ -4,13 +4,13 @@ public class RagQueryWorker : ChannelBackgroundWorker<RagQueryRequest>
 {
     private readonly ILogger<RagQueryWorker> _logger;
     private readonly IEmbeddingService _embedding;
-    private readonly VectorStoreService _vectorStore;
+    private readonly IVectorStoreService _vectorStore;
 
     public RagQueryWorker(
         IRagQueryQueue queue,
         ILogger<RagQueryWorker> logger,
         IEmbeddingService embedding,
-        VectorStoreService vectorStore)
+        IVectorStoreService vectorStore)
         : base(queue, logger)
     {
         _logger = logger;

--- a/RagWebScraper/Services/RagResearchAgent.cs
+++ b/RagWebScraper/Services/RagResearchAgent.cs
@@ -1,0 +1,49 @@
+
+
+namespace RagWebScraper.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IRagResearchAgent"/>.
+/// </summary>
+public sealed class RagResearchAgent : IRagResearchAgent
+{
+    private readonly IEmbeddingService _embedding;
+    private readonly IVectorStoreService _vectorStore;
+    private readonly IChatCompletionService _chat;
+
+    public RagResearchAgent(
+        IEmbeddingService embedding,
+        IVectorStoreService vectorStore,
+        IChatCompletionService chat)
+    {
+        _embedding = embedding;
+        _vectorStore = vectorStore;
+        _chat = chat;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ResearchAsync(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return "Query cannot be empty.";
+
+        var embedding = await _embedding.GetEmbeddingAsync(query);
+        var results = await _vectorStore.QueryAsync(embedding, topK: 5);
+        var passages = results
+            .Select(r => r.payload != null && r.payload.ContainsKey("ChunkText")
+                ? r.payload["ChunkText"]?.ToString()
+                : string.Empty)
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+
+        if (passages.Count == 0)
+            return "No relevant documents found.";
+
+        var context = string.Join("\n---\n", passages);
+        var prompt = $"{context}\n\nProvide a concise comparison highlighting any differing rules or interpretations.";
+        var systemPrompt = "You are an expert researcher skilled in finding nuanced rules and differences across documents.";
+
+        var result = await _chat.GetCompletionAsync(systemPrompt, prompt);
+        return string.IsNullOrWhiteSpace(result) ? "No response." : result;
+    }
+}

--- a/RagWebScraper/Services/VectorStoreService.cs
+++ b/RagWebScraper/Services/VectorStoreService.cs
@@ -2,7 +2,7 @@
 
 namespace RagWebScraper.Services
 {
-    public class VectorStoreService
+    public class VectorStoreService : IVectorStoreService
     {
         private readonly HttpClient _httpClient;
         private readonly string _collectionName = "rag";


### PR DESCRIPTION
## Summary
- implement `IRagResearchAgent` and `RagResearchAgent`
- add `IChatCompletionService` with OpenAI implementation
- abstract vector store behind `IVectorStoreService`
- register new services in DI container
- update existing services to depend on interfaces
- create unit tests for the research agent

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685e978beab8832cbb97942b241a794e