### PR TITLE
Dispose streams before deleting files

### DIFF
--- a/RagWebScraper.Tests/DocumentUploadPageTests.cs
+++ b/RagWebScraper.Tests/DocumentUploadPageTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using RagWebScraper.Pages;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class DocumentUploadPageTests
+{
+    private class TrackingStream : MemoryStream
+    {
+        public bool IsDisposed { get; private set; }
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            IsDisposed = true;
+        }
+    }
+
+    private class StubBrowserFile : IBrowserFile
+    {
+        private readonly TrackingStream _stream;
+        public StubBrowserFile(string name, int size)
+        {
+            Name = name;
+            _stream = new TrackingStream();
+            _stream.SetLength(size);
+        }
+
+        public DateTimeOffset LastModified => DateTimeOffset.Now;
+        public string Name { get; }
+        public long Size => _stream.Length;
+        public string ContentType => "application/pdf";
+        public bool Disposed => _stream.IsDisposed;
+
+        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default)
+        {
+            _stream.Position = 0;
+            return _stream;
+        }
+    }
+
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? Request { get; private set; }
+        public StubHandler(HttpResponseMessage response) => _response = response;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    private class NavStub : NavigationManager
+    {
+        public NavStub(string baseUri) => Initialize(baseUri, baseUri);
+        protected override void NavigateToCore(string uri, bool forceLoad) { }
+    }
+
+    private static void SetPrivateField(object obj, string name, object? value)
+        => obj.GetType().GetField(name, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(obj, value);
+
+    private static Task InvokePrivateMethod(object obj, string name)
+    {
+        var method = obj.GetType().GetMethod(name, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        return (Task)method.Invoke(obj, Array.Empty<object>())!;
+    }
+
+    [Fact]
+    public async Task UploadFiles_DisposesStreams()
+    {
+        var handler = new StubHandler(new HttpResponseMessage(HttpStatusCode.BadRequest));
+        var page = new DocumentUpload();
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        page.GetType().GetProperty("Http", flags)!.SetValue(page, new HttpClient(handler));
+        page.GetType().GetProperty("Navigation", flags)!.SetValue(page, new NavStub("http://base/"));
+
+        var files = new List<IBrowserFile>
+        {
+            new StubBrowserFile("a.pdf", 150_000),
+            new StubBrowserFile("b.pdf", 160_000)
+        };
+        SetPrivateField(page, "selectedFiles", files);
+
+        await InvokePrivateMethod(page, "UploadFiles");
+
+        Assert.NotNull(handler.Request); // request was sent
+        Assert.All(files, f => Assert.True(((StubBrowserFile)f).Disposed));
+    }
+}

--- a/RagWebScraper.Tests/PdfProcessingWorkerTests.cs
+++ b/RagWebScraper.Tests/PdfProcessingWorkerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using RagWebScraper.Models;
+using RagWebScraper.Services;
+using Xunit;
+
+namespace RagWebScraper.Tests;
+
+public class PdfProcessingWorkerTests
+{
+    private class StubExtractor : ITextExtractor
+    {
+        public Task<string> ExtractTextAsync(Stream pdfStream) => Task.FromResult("text");
+    }
+
+    private class StubSentiment : ISentimentAnalyzer
+    {
+        public float AnalyzeSentiment(string text) => 0.5f;
+    }
+
+    private class StubKeywordExtractor : IKeywordExtractor
+    {
+        public Dictionary<string, int> ExtractKeywords(string text, List<string> keywords) => new();
+    }
+
+    private class StubKeywordContext : IKeywordContextSentimentService
+    {
+        public Dictionary<string, float> ExtractKeywordSentiments(string text, IEnumerable<string> keywords) => new();
+    }
+
+    private class StubChunkIngestor : IChunkIngestorService
+    {
+        public Task IngestChunksAsync(string sourceLabel, string text, Dictionary<string, object>? extraMetadata = null) => Task.CompletedTask;
+    }
+
+    private class StubQueue : IPdfProcessingQueue
+    {
+        public void Enqueue(PdfProcessingRequest request) { }
+        public async IAsyncEnumerable<PdfProcessingRequest> ReadAllAsync(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private class TestWorker : PdfProcessingWorker
+    {
+        public TestWorker() : base(new StubQueue(), NullLogger<PdfProcessingWorker>.Instance, new StubExtractor(), new StubSentiment(), new StubKeywordExtractor(), new StubKeywordContext(), new StubChunkIngestor(), new PdfResultStore()) { }
+        public Task HandleAsync(PdfProcessingRequest request) => base.ProcessRequestAsync(request, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ProcessRequestAsync_DeletesFileAfterProcessing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pdf");
+        await File.WriteAllTextAsync(path, "dummy");
+        var worker = new TestWorker();
+
+        await worker.HandleAsync(new PdfProcessingRequest
+        {
+            FileName = "test.pdf",
+            FilePath = path,
+            Keywords = new List<string>()
+        });
+
+        Assert.False(File.Exists(path));
+    }
+}

--- a/RagWebScraper/Pages/DocumentUpload.razor
+++ b/RagWebScraper/Pages/DocumentUpload.razor
@@ -289,8 +289,8 @@
             return;
         }
 
-        var pdfForm = new MultipartFormDataContent();
-        var jsonForm = new MultipartFormDataContent();
+        using var pdfForm = new MultipartFormDataContent();
+        using var jsonForm = new MultipartFormDataContent();
 
         foreach (var file in selectedFiles)
         {

--- a/RagWebScraper/Services/PdfProcessingWorker.cs
+++ b/RagWebScraper/Services/PdfProcessingWorker.cs
@@ -35,8 +35,12 @@ public class PdfProcessingWorker : ChannelBackgroundWorker<PdfProcessingRequest>
 
     protected override async Task ProcessRequestAsync(PdfProcessingRequest request, CancellationToken stoppingToken)
     {
-        await using var stream = new FileStream(request.FilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        var text = await _extractor.ExtractTextAsync(stream);
+        string text;
+        using (var stream = new FileStream(request.FilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            text = await _extractor.ExtractTextAsync(stream);
+        }
+
         var sentences = SentenceSplitter.Split(text);
 
         var sentiment = _sentiment.AnalyzeSentiment(text);


### PR DESCRIPTION
## Summary
- Ensure PDF worker closes streams before cleaning up temp files
- Dispose upload form streams to prevent Blazor circuit timeouts
- Add unit tests for PDF processing worker and document upload

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68954366a778832c834884a8dab4cdc0