### PR TITLE
Include sources and AI commentary in RAG query results

### DIFF
--- a/RagWebScraper/Controllers/RAGQueryController.cs
+++ b/RagWebScraper/Controllers/RAGQueryController.cs
@@ -14,7 +14,7 @@ public class RAGQueryController : ControllerBase
     }
 
     [HttpPost("query")]
-    public async Task<ActionResult<List<string>>> QueryRag([FromBody] RAGQueryRequest request)
+    public async Task<ActionResult<RAGQueryResponse>> QueryRag([FromBody] RAGQueryRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.Query))
             return BadRequest("Query cannot be empty.");

--- a/RagWebScraper/Models/RAGQueryResponse.cs
+++ b/RagWebScraper/Models/RAGQueryResponse.cs
@@ -1,0 +1,19 @@
+namespace RagWebScraper.Models;
+
+/// <summary>
+/// Represents a single retrieved passage and its source.
+/// </summary>
+public class RAGQueryResult
+{
+    public string ChunkText { get; set; } = string.Empty;
+    public string? Source { get; set; }
+}
+
+/// <summary>
+/// Response returned from a RAG query, including passages and AI commentary.
+/// </summary>
+public class RAGQueryResponse
+{
+    public List<RAGQueryResult> Results { get; set; } = new();
+    public string Commentary { get; set; } = string.Empty;
+}

--- a/RagWebScraper/Pages/RAGQuery.razor
+++ b/RagWebScraper/Pages/RAGQuery.razor
@@ -21,14 +21,28 @@
     </div>
 </div>
 
-@if (results != null && results.Any())
+@if (queryResponse?.Results != null && queryResponse.Results.Any())
 {
     <h4>Top Retrieved Chunks:</h4>
-    @foreach (var result in results)
+    @foreach (var result in queryResponse.Results)
     {
         <div class="card mb-2">
             <div class="card-body">
-                <div class="text-wrap" style="white-space: pre-wrap;">@result</div>
+                <div class="text-wrap" style="white-space: pre-wrap;">@result.ChunkText</div>
+                @if (!string.IsNullOrEmpty(result.Source))
+                {
+                    <div class="mt-2"><strong>Source:</strong> @result.Source</div>
+                }
+            </div>
+        </div>
+    }
+
+    @if (!string.IsNullOrWhiteSpace(queryResponse.Commentary))
+    {
+        <h4>AI Commentary:</h4>
+        <div class="card mb-2">
+            <div class="card-body">
+                <div class="text-wrap" style="white-space: pre-wrap;">@queryResponse.Commentary</div>
             </div>
         </div>
     }
@@ -37,7 +51,7 @@
 
 @code {
     private string? userQuery;
-    private List<string>? results;
+    private RAGQueryResponse? queryResponse;
 
     private async Task QueryRagAsync()
     {
@@ -54,15 +68,27 @@
             {
                 var errorContent = await response.Content.ReadAsStringAsync();
                 Console.WriteLine($"Error from API: {response.StatusCode} - {errorContent}");
-                results = new List<string> { $"Error: {response.StatusCode} - {errorContent}" };
+                queryResponse = new RAGQueryResponse
+                {
+                    Results = new List<RAGQueryResult>
+                    {
+                        new() { ChunkText = $"Error: {response.StatusCode} - {errorContent}" }
+                    }
+                };
                 return;
             }
 
-            results = await response.Content.ReadFromJsonAsync<List<string>>();
+            queryResponse = await response.Content.ReadFromJsonAsync<RAGQueryResponse>();
         }
         catch (Exception ex)
         {
-            results = new List<string> { $"Error querying RAG: {ex.Message}" };
+            queryResponse = new RAGQueryResponse
+            {
+                Results = new List<RAGQueryResult>
+                {
+                    new() { ChunkText = $"Error querying RAG: {ex.Message}" }
+                }
+            };
         }
     }
 }

--- a/RagWebScraper/Services/RagQueryRequest.cs
+++ b/RagWebScraper/Services/RagQueryRequest.cs
@@ -1,7 +1,12 @@
+using RagWebScraper.Models;
+
 namespace RagWebScraper.Services;
 
+/// <summary>
+/// Request object used for queued RAG queries.
+/// </summary>
 public class RagQueryRequest
 {
     public required string Query { get; init; }
-    public TaskCompletionSource<List<string>> Completion { get; init; } = new();
+    public TaskCompletionSource<RAGQueryResponse> Completion { get; } = new();
 }

--- a/RagWebScraper/Services/RagQueryWorker.cs
+++ b/RagWebScraper/Services/RagQueryWorker.cs
@@ -1,31 +1,66 @@
+using RagWebScraper.Models;
+
 namespace RagWebScraper.Services;
 
+/// <summary>
+/// Background worker that processes queued RAG queries.
+/// </summary>
 public class RagQueryWorker : ChannelBackgroundWorker<RagQueryRequest>
 {
     private readonly ILogger<RagQueryWorker> _logger;
     private readonly IEmbeddingService _embedding;
     private readonly IVectorStoreService _vectorStore;
+    private readonly IChatCompletionService _chat;
 
     public RagQueryWorker(
         IRagQueryQueue queue,
         ILogger<RagQueryWorker> logger,
         IEmbeddingService embedding,
-        IVectorStoreService vectorStore)
+        IVectorStoreService vectorStore,
+        IChatCompletionService chat)
         : base(queue, logger)
     {
         _logger = logger;
         _embedding = embedding;
         _vectorStore = vectorStore;
+        _chat = chat;
     }
 
     protected override async Task ProcessRequestAsync(RagQueryRequest request, CancellationToken stoppingToken)
     {
         var embedding = await _embedding.GetEmbeddingAsync(request.Query);
         var results = await _vectorStore.QueryAsync(embedding);
-        var texts = results.Select(r =>
-            r.payload != null && r.payload.ContainsKey("ChunkText")
-                ? r.payload["ChunkText"]?.ToString()
-                : "[Missing ChunkText]").ToList();
-        request.Completion.SetResult(texts);
+
+        var passages = results.Select(r => new RAGQueryResult
+        {
+            ChunkText = r.payload != null && r.payload.ContainsKey("ChunkText")
+                ? r.payload["ChunkText"]?.ToString() ?? string.Empty
+                : "[Missing ChunkText]",
+            Source = r.payload != null && r.payload.ContainsKey("Source")
+                ? r.payload["Source"]?.ToString()
+                : null
+        }).ToList();
+
+        var commentary = string.Empty;
+        if (passages.Count > 0)
+        {
+            try
+            {
+                var context = string.Join("\n---\n", passages.Select(p => p.ChunkText));
+                var prompt = $"{context}\n\nProvide a brief commentary linking these passages.";
+                var systemPrompt = "You are an assistant that offers insightful commentary on retrieved passages.";
+                commentary = await _chat.GetCompletionAsync(systemPrompt, prompt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to generate commentary for query.");
+            }
+        }
+
+        request.Completion.SetResult(new RAGQueryResponse
+        {
+            Results = passages,
+            Commentary = commentary
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add RAGQueryResponse and RAGQueryResult models to include source metadata and commentary
- enhance RagQueryWorker to collect sources and generate AI commentary via chat service
- update API and Razor page to return structured results and display commentary

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6896230b4368832cac657c0389b71e96