### PR TITLE
feat: explain K-means clusters with keywords

### DIFF
--- a/RagWebScraper.Tests/DocumentClustererTests.cs
+++ b/RagWebScraper.Tests/DocumentClustererTests.cs
@@ -24,6 +24,7 @@ public class DocumentClustererTests
         Assert.Equal(docs.Length, result.Clusters.Count);
         var unique = new HashSet<int>(result.Clusters.Values);
         Assert.Equal(2, unique.Count);
+        Assert.Equal(2, result.Descriptors.Count);
     }
 
     [Fact]
@@ -104,5 +105,6 @@ public class DocumentClustererTests
 
         Assert.True(result.Metrics.AverageDistance > 0);
         Assert.True(result.Metrics.DaviesBouldinIndex >= 0);
+        Assert.Equal(2, result.Descriptors.Count);
     }
 }

--- a/RagWebScraper.Tests/KMeansClusteringPageTests.cs
+++ b/RagWebScraper.Tests/KMeansClusteringPageTests.cs
@@ -19,7 +19,7 @@ public class KMeansClusteringPageTests
         public List<Document>? ReceivedDocs { get; private set; }
         public int ReceivedK { get; private set; }
         public DocumentClusteringResult Result { get; set; } =
-            new(new Dictionary<Guid, int>(), new ClusterMetrics(0, 0, 0));
+            new(new Dictionary<Guid, int>(), new ClusterMetrics(0, 0, 0), new List<ClusterDescriptor>());
         public Exception? ExceptionToThrow { get; set; }
 
         public Task<DocumentClusteringResult> ClusterAsync(IEnumerable<Document> documents, int numberOfClusters = 5)
@@ -112,7 +112,7 @@ public class KMeansClusteringPageTests
     {
         var clusterer = new StubClusterer
         {
-            Result = new DocumentClusteringResult(new() { { Guid.NewGuid(), 1 } }, new ClusterMetrics(0, 0, 0))
+            Result = new DocumentClusteringResult(new() { { Guid.NewGuid(), 1 } }, new ClusterMetrics(0, 0, 0), new List<ClusterDescriptor>())
         };
         var page = new RagWebScraper.Pages.KMeansClustering();
         page.GetType().GetProperty("Clusterer", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
@@ -158,7 +158,7 @@ public class KMeansClusteringPageTests
     {
         var page = new RagWebScraper.Pages.KMeansClustering();
         var results = new Dictionary<Guid, int> { [Guid.NewGuid()] = 0 };
-        var clusteringResult = new DocumentClusteringResult(results, new ClusterMetrics(0, 0, 0));
+        var clusteringResult = new DocumentClusteringResult(results, new ClusterMetrics(0, 0, 0), new List<ClusterDescriptor>());
         SetPrivateField(page, "clusterResult", clusteringResult);
         var builder = new RenderTreeBuilder();
         var method = page.GetType().GetMethod("BuildRenderTree", BindingFlags.Instance | BindingFlags.NonPublic)!;

--- a/RagWebScraper/Models/ClusterDescriptor.cs
+++ b/RagWebScraper/Models/ClusterDescriptor.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace RagWebScraper.Models
+{
+    /// <summary>
+    /// Provides descriptive information about a single cluster.
+    /// </summary>
+    public record ClusterDescriptor(
+        int ClusterId,
+        IReadOnlyList<string> TopWords,
+        string Reason);
+}

--- a/RagWebScraper/Models/DocumentClusteringResult.cs
+++ b/RagWebScraper/Models/DocumentClusteringResult.cs
@@ -4,10 +4,12 @@ using System.Collections.Generic;
 namespace RagWebScraper.Models
 {
     /// <summary>
-    /// Represents the outcome of clustering documents, including assignments and metrics.
+    /// Represents the outcome of clustering documents, including assignments,
+    /// metrics, and descriptive information for each cluster.
     /// </summary>
     public record DocumentClusteringResult(
         Dictionary<Guid, int> Clusters,
-        ClusterMetrics Metrics);
+        ClusterMetrics Metrics,
+        IReadOnlyList<ClusterDescriptor> Descriptors);
 }
 

--- a/RagWebScraper/Pages/KMeansClustering.razor
+++ b/RagWebScraper/Pages/KMeansClustering.razor
@@ -4,6 +4,7 @@
 @inject ITextExtractor TextExtractor
 @using RagWebScraper.Models
 @using Microsoft.AspNetCore.Components.Forms
+@using System.Linq
 
 @implements IDisposable
 
@@ -64,8 +65,14 @@
 
     @foreach (var group in clusterResult.Clusters.GroupBy(r => r.Value))
     {
+        var descriptor = clusterResult.Descriptors.FirstOrDefault(d => d.ClusterId == group.Key);
         <div class="mb-3">
             <h5>Cluster @group.Key</h5>
+            @if (descriptor is not null)
+            {
+                <p><strong>Reason:</strong> @descriptor.Reason</p>
+                <p><strong>Top Words:</strong> @string.Join(", ", descriptor.TopWords)</p>
+            }
             <ul>
                 @foreach (var doc in group)
                 {

--- a/RagWebScraper/Services/IDocumentClusterer.cs
+++ b/RagWebScraper/Services/IDocumentClusterer.cs
@@ -12,7 +12,7 @@ namespace RagWebScraper.Services
         /// </summary>
         /// <param name="documents">Documents to cluster.</param>
         /// <param name="numberOfClusters">Desired number of clusters.</param>
-        /// <returns>Cluster assignments and associated metrics.</returns>
+        /// <returns>Cluster assignments, metrics, and descriptive details.</returns>
         Task<DocumentClusteringResult> ClusterAsync(IEnumerable<Document> documents, int numberOfClusters = 5);
     }
 }


### PR DESCRIPTION
## Summary
- expand clustering result to include descriptive details per cluster
- compute top keywords for each cluster and expose as reasoning
- display cluster keywords and reasons on K-Means page
- cover new cluster descriptions in tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b300216838832cbb427bcd789dfa13